### PR TITLE
Add zero determinant checks in heat exchanger solver

### DIFF
--- a/src/main/java/neqsim/process/equipment/heatexchanger/MultiStreamHeatExchanger2.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/MultiStreamHeatExchanger2.java
@@ -224,6 +224,9 @@ public class MultiStreamHeatExchanger2 extends Heater implements MultiStreamHeat
   }
 
   private double[] linearSystemOneUnknown(double[][] A, double[] b) {
+    if (Math.abs(A[0][0]) < 1e-12) {
+      throw new ArithmeticException("Jacobian element is zero");
+    }
     return new double[] {b[0] / A[0][0]};
   }
 
@@ -289,6 +292,9 @@ public class MultiStreamHeatExchanger2 extends Heater implements MultiStreamHeat
 
   private double[] linearSystemTwoUnknowns(double[][] A, double[] b) {
     double det = A[0][0] * A[1][1] - A[0][1] * A[1][0];
+    if (Math.abs(det) < 1e-12) {
+      throw new ArithmeticException("Jacobian determinant is zero");
+    }
     double dx = b[0] * A[1][1] - b[1] * A[0][1];
     double dy = A[0][0] * b[1] - A[1][0] * b[0];
     return new double[] {dx / det, dy / det};
@@ -366,6 +372,9 @@ public class MultiStreamHeatExchanger2 extends Heater implements MultiStreamHeat
     double D = A[0][0] * (A[1][1] * A[2][2] - A[1][2] * A[2][1])
         - A[0][1] * (A[1][0] * A[2][2] - A[1][2] * A[2][0])
         + A[0][2] * (A[1][0] * A[2][1] - A[1][1] * A[2][0]);
+    if (Math.abs(D) < 1e-12) {
+      throw new ArithmeticException("Jacobian determinant is zero");
+    }
 
     double Dx = b[0] * (A[1][1] * A[2][2] - A[1][2] * A[2][1])
         - A[0][1] * (b[1] * A[2][2] - A[1][2] * b[2]) + A[0][2] * (b[1] * A[2][1] - A[1][1] * b[2]);


### PR DESCRIPTION
## Summary
- add arithmetic checks for zero denominators in `MultiStreamHeatExchanger2`

## Testing
- `./mvnw -q test` *(fails: Could not find or load main class org.apache.maven.wrapper.MavenWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_6850009885b8832d9a311db0aab8839d