### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 
 NeqSim is the main part of the [NeqSim project](https://equinor.github.io/neqsimhome/). NeqSim (Non-Equilibrium Simulator) is a Java library for estimating fluid properties and process design.
-The basis for NeqSim is a library of fundamental mathematical models related to phase behavior and physical properties of fluids.  NeqSim is easilly extended with new models. NeqSim development was initiated at the [Norwegian University of Science and Technology (NTNU)](https://www.ntnu.edu/employees/even.solbraa).
+The basis for NeqSim is a library of fundamental mathematical models related to phase behavior and physical properties of fluids.  NeqSim is easily extended with new models. NeqSim development was initiated at the [Norwegian University of Science and Technology (NTNU)](https://www.ntnu.edu/employees/even.solbraa).
 
 ## Releases
 
@@ -28,7 +28,7 @@ NeqSim can be built using the Maven build system (https://maven.apache.org/). Al
 
 ### Initial setup
 
-The NeqSim source code is downloaded by cloning the library to your local computer (alternatively fork it to your private reprository). The following commands are dependent on a local installation of [GIT](https://git-scm.com/) and [Maven](https://maven.apache.org/).
+The NeqSim source code is downloaded by cloning the library to your local computer (alternatively fork it to your private repository). The following commands are dependent on a local installation of [GIT](https://git-scm.com/) and [Maven](https://maven.apache.org/).
 
 ```bash
 git clone https://github.com/equinor/neqsim.git
@@ -36,7 +36,7 @@ cd neqsim
 ./mvnw install
 ```
 > **Note**
-> The maven wrapper command is dependend on your OS, for Unix use: ```./mvnw```
+> The maven wrapper command is dependent on your OS, for Unix use: ```./mvnw```
 > Windows:
 > ```mvnw.cmd ```
 
@@ -44,12 +44,12 @@ An interactive demonstration of how to get started as a NeqSim developer is pres
 
 ## Running the tests
 
-The test files are written in JUnit5 and placed in the [test directory](https://github.com/equinor/neqsim/tree/master/src/test). Test code shuld be written for all new code added to the project, and all tests have to pass before merging into the master branch.  
+The test files are written in JUnit5 and placed in the [test directory](https://github.com/equinor/neqsim/tree/master/src/test). Test code should be written for all new code added to the project, and all tests have to pass before merging into the master branch.  
 
 Test coverage can be examined using [jacoco](https://www.eclemma.org/jacoco/) from maven.  
 Generate a coverage report using `./mvnw jacoco:prepare-agent test install jacoco:report` and see results in target/site/jacoco/index.html.
 > **Note**
-> The maven wrapper command is dependend on your OS, for Unix use: ```./mvnw```
+> The maven wrapper command is dependent on your OS, for Unix use: ```./mvnw```
 > Windows:
 > ```mvnw.cmd ```
 
@@ -72,7 +72,7 @@ Questions related to neqsim can be posted in the [github discussion pages](https
 
 ## Versioning
 
-NeqSim use [SemVer](https://semver.org/) for versioning.
+NeqSim uses [SemVer](https://semver.org/) for versioning.
 
 ## Authors and contact persons
 
@@ -88,7 +88,7 @@ A number of master and PhD students at NTNU have contributed to development of N
 
 ## NeqSim modules
 
-NeqSim is built upon six base modules:
+NeqSim is built upon seven base modules:
 
 1. Thermodynamic Routines
 2. Physical Properties Routines
@@ -122,7 +122,7 @@ NeqSim is built upon six base modules:
 
 ## Toolboxes
 
-See [NeqSim homepage](https://equinor.github.io/neqsimhome/). NeqSim toolboxes are avalable via GitHub for alternative programming languages.
+See [NeqSim homepage](https://equinor.github.io/neqsimhome/). NeqSim toolboxes are available via GitHub for alternative programming languages.
 
 * [Matlab](https://github.com/equinor/neqsimmatlab)
 * [Python](https://github.com/equinor/neqsimpython)


### PR DESCRIPTION
## Summary
- fix minor typos in the README
- correct grammar in the versioning section
- update toolbox section wording

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685007caea80832dad875b9af203c351