### PR TITLE
Fix Cv property retrieval

### DIFF
--- a/src/main/java/neqsim/util/generator/PropertyGenerator.java
+++ b/src/main/java/neqsim/util/generator/PropertyGenerator.java
@@ -131,7 +131,7 @@ public class PropertyGenerator {
       enthalpy[i] = fluid.getEnthalpy("J/mol");
       entropy[i] = fluid.getEntropy("J/molK");
       Cp[i] = fluid.getCp("kJ/kgK");
-      Cv[i] = fluid.getCp("kJ/kgK");
+      Cv[i] = fluid.getCv("kJ/kgK");
       density[i] = fluid.getDensity("kg/m3");
       numberOfPhases[i] = fluid.getNumberOfPhases();
       locpressure[i] = fluid.getPressure("Pa");


### PR DESCRIPTION
## Summary
- use `getCv` instead of `getCp` when populating mixture Cv in `PropertyGenerator`

## Testing
- `mvn test` *(fails: Plugin org.apache.maven.plugins:maven-enforcer-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_685256bb82c8832d97a12a9e61697399