### PR TITLE
Fix beta bug in constantPhaseFractionTemperatureFlash

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
+++ b/src/main/java/neqsim/thermodynamicoperations/ThermodynamicOperations.java
@@ -1430,9 +1430,8 @@ public class ThermodynamicOperations implements java.io.Serializable, Cloneable 
       fraction = 1.0 - 1.0e-10;
     }
     ConstantDutyFlashInterface operation = new ConstantDutyTemperatureFlash(system);
-    // TODO: bug, sum of beta will not equal 1
-    system.setBeta(1, fraction);
     system.setBeta(0, fraction);
+    system.setBeta(1, 1.0 - fraction);
     operation.run();
     if (Double.isNaN(system.getPressure()) || operation.isSuperCritical()) {
       throw new neqsim.util.exception.IsNaNException(this, "constantPhaseFractionTemperatureFlash",


### PR DESCRIPTION
## Summary
- correct phase fraction initialization so betas sum to 1

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `./mvnw -q checkstyle:check` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68532d4f9690832d82f658832e79c823