### PR TITLE
Add humid air mathematics documentation

### DIFF
--- a/docs/wiki/humid_air_math.md
+++ b/docs/wiki/humid_air_math.md
@@ -1,0 +1,44 @@
+# Humid air mathematics
+
+This page summarises the equations implemented in the `HumidAir` utility class for psychrometric calculations. The correlations are based on the ASHRAE Handbook Fundamentals (2017), CoolProp and the IAPWS formulation for the saturation pressure of water.
+
+## Saturation pressure of water
+For temperatures $T$ above the triple point the saturation vapour pressure $p_{ws}$ in pascal is given by the IAPWS equation of Wagner and Pruss (2002)
+
+$$
+\ln\left(\frac{p_{ws}}{p_c}\right) = \frac{T_c}{T}\left(a_1\theta + a_2\theta^{3/2} + a_3\theta^3 + a_4\theta^{7/2} + a_5\theta^4 + a_6\theta^{15/2}\right)
+$$
+
+where $\theta = 1 - T/T_c$, $T_c = 647.096\ \text{K}$ and $p_c = 22.064\ \text{MPa}$. Below the triple point a sublimation correlation is used.
+
+## Humidity ratio
+The humidity ratio $W$ relates the mass of water vapour to the mass of dry air
+
+$$
+W = \varepsilon \frac{p_w}{p - p_w}
+$$
+
+where $\varepsilon = M_w/M_{da} \approx 0.621945$, $p$ is the total pressure and $p_w$ the partial pressure of water.
+
+For a given relative humidity $\phi$, the partial pressure is $p_w = \phi p_{ws}$.
+
+## Dew point temperature
+Given a humidity ratio, the dew point temperature $T_d$ is found by solving $p_{ws}(T_d) = p_w$. The `HumidAir` implementation uses a simple Newton iteration.
+
+## Specific enthalpy
+On a dry-air basis the specific enthalpy $h$ in kJ/kg dry air is approximated by
+
+$$
+h = 1.006\,t + W (2501 + 1.86\,t)
+$$
+
+where $t$ is the temperature in degrees Celsius and $W$ is the humidity ratio.
+
+## Saturated specific heat
+CoolProp provides a correlation for the saturated humid-air specific heat $c_{p,\text{sat}}$ at 1\,atm valid from 250\,K to 300\,K
+
+$$
+c_{p,\text{sat}} = 2.146\,27073 \times 10^{3} - 3.289\,17768 \times 10^{1}T + 1.894\,71075 \times 10^{-1}T^2 \\
+ - 4.862\,90986 \times 10^{-4}T^3 + 4.695\,40143 \times 10^{-7}T^4.
+$$
+

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -13,3 +13,4 @@ This folder holds additional documentation for the NeqSim project. Below are use
 
 - [JUnit test overview](test-overview.md)
 - [Distillation column algorithm](distillation_column.md)
+- [Humid air mathematics](humid_air_math.md)

--- a/src/main/java/neqsim/thermo/util/humidair/HumidAir.java
+++ b/src/main/java/neqsim/thermo/util/humidair/HumidAir.java
@@ -1,0 +1,136 @@
+package neqsim.thermo.util.humidair;
+
+/**
+ * Utility class for common humid air calculations.
+ *
+ * <p>The methods are adapted from the ASHRAE Handbook Fundamentals (2017)
+ * and the <a href="https://github.com/CoolProp/CoolProp">CoolProp</a>
+ * implementation {@code HumidAirProp.cpp}. Saturation vapour pressures are
+ * calculated from the IAPWS formulation of Wagner and Pruss (2002).</p>
+ */
+public final class HumidAir {
+
+    /** Ratio of molar masses M_w/M_da. */
+    private static final double EPSILON = 0.621945;
+
+    private HumidAir() {}
+
+    /**
+     * Saturation vapour pressure of water.
+     *
+     * <p>Implementation of the IAPWS equation for the vapour pressure of
+     * water valid above the triple point. For temperatures below the
+     * triple point, a simplified sublimation correlation is applied.</p>
+     *
+     * @param temperature Temperature in K
+     * @return saturation pressure in Pa
+     */
+    public static double saturationPressureWater(double temperature) {
+        if (temperature >= 273.16) {
+            // IAPWS formulation for saturation pressure of liquid water
+            double Tc = 647.096; // K
+            double Pc = 22064000; // Pa
+            double theta = 1 - temperature / Tc;
+            double a1 = -7.85951783;
+            double a2 = 1.84408259;
+            double a3 = -11.7866497;
+            double a4 = 22.6807411;
+            double a5 = -15.9618719;
+            double a6 = 1.80122502;
+            double lnP = Tc / temperature
+                    * (a1 * theta + a2 * Math.pow(theta, 1.5) + a3 * Math.pow(theta, 3)
+                            + a4 * Math.pow(theta, 3.5) + a5 * Math.pow(theta, 4)
+                            + a6 * Math.pow(theta, 7.5));
+            return Pc * Math.exp(lnP);
+        }
+        // Sublimation pressure over ice, IAPWS formulation
+        double theta = temperature / 273.16;
+        double lnP = -13.928169 * (1 - Math.pow(theta, -1.5))
+                - 34.7078238 * (1 - Math.pow(theta, 1.5)) + Math.log(611.657);
+        return Math.exp(lnP);
+    }
+
+    /**
+     * Humidity ratio from temperature, pressure and relative humidity.
+     *
+     * <p>Formula from ASHRAE Fundamentals (2017) with enhancement factor
+     * neglected.</p>
+     *
+     * @param temperature Temperature in K
+     * @param pressure total pressure in Pa
+     * @param relativeHumidity relative humidity [-]
+     * @return humidity ratio (kg water/kg dry air)
+     */
+    public static double humidityRatioFromRH(double temperature, double pressure,
+            double relativeHumidity) {
+        double pws = saturationPressureWater(temperature);
+        double pw = relativeHumidity * pws;
+        return EPSILON * pw / (pressure - pw);
+    }
+
+    /**
+     * Relative humidity from humidity ratio.
+     *
+     * @param temperature temperature in K
+     * @param pressure total pressure in Pa
+     * @param humidityRatio humidity ratio (kg/kg dry air)
+     * @return relative humidity [-]
+     */
+    public static double relativeHumidity(double temperature, double pressure,
+            double humidityRatio) {
+        double pws = saturationPressureWater(temperature);
+        double pw = humidityRatio * pressure / (EPSILON + humidityRatio);
+        return pw / pws;
+    }
+
+    /**
+     * Dew point temperature from humidity ratio and pressure.
+     *
+     * <p>Calculated iteratively using the saturation pressure correlation.</p>
+     *
+     * @param humidityRatio humidity ratio (kg/kg dry air)
+     * @param pressure total pressure in Pa
+     * @return dew point temperature in K
+     */
+    public static double dewPointTemperature(double humidityRatio, double pressure) {
+        double pw = humidityRatio * pressure / (EPSILON + humidityRatio);
+        double T = 273.15; // initial guess
+        for (int i = 0; i < 50; i++) {
+            double f = saturationPressureWater(T) - pw;
+            if (Math.abs(f / pw) < 1e-6) {
+                return T;
+            }
+            double dP = (saturationPressureWater(T + 0.01) - saturationPressureWater(T - 0.01)) / 0.02;
+            T -= f / dP;
+        }
+        return T;
+    }
+
+    /**
+     * Specific enthalpy of humid air on a dry-air basis.
+     *
+     * <p>Correlation from ASHRAE Fundamentals (2017) in kJ/kg dry air.</p>
+     *
+     * @param temperature temperature in K
+     * @param humidityRatio humidity ratio (kg/kg dry air)
+     * @return specific enthalpy in kJ/kg dry air
+     */
+    public static double enthalpy(double temperature, double humidityRatio) {
+        double tC = temperature - 273.15;
+        return 1.006 * tC + humidityRatio * (2501.0 + 1.86 * tC);
+    }
+
+    /**
+     * Humid air saturation specific heat at 1 atmosphere.
+     *
+     * <p>Correlation from CoolProp based on EES, valid from 250&nbsp;K to 300&nbsp;K.</p>
+     *
+     * @param temperature temperature in K
+     * @return specific heat in kJ/kg·K
+     */
+    public static double cairSat(double temperature) {
+        double T = temperature;
+        return 2.14627073E+03 - 3.28917768E+01 * T + 1.89471075E-01 * T * T
+                - 4.86290986E-04 * T * T * T + 4.69540143E-07 * T * T * T * T;
+    }
+}

--- a/src/test/java/neqsim/thermo/util/humidair/HumidAirTest.java
+++ b/src/test/java/neqsim/thermo/util/humidair/HumidAirTest.java
@@ -1,0 +1,59 @@
+package neqsim.thermo.util.humidair;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link HumidAir}.
+ *
+ * <p>All quantities are in SI units unless otherwise noted.</p>
+ */
+class HumidAirTest {
+
+    /**
+     * Validate humidity ratio calculation.
+     *
+     * <p>Inputs: temperature in Kelvin, pressure in Pascal and relative humidity
+     * as a fraction. The expected humidity ratio is expressed in kg water per kg
+     * dry air.</p>
+     */
+    @Test
+    void testHumidityRatioFromRH() {
+        double T = 303.15; // 30 °C
+        double p = 101325.0; // Pa
+        double rh = 0.5; // 50 % RH
+
+        double W = HumidAir.humidityRatioFromRH(T, p, rh);
+
+        assertEquals(0.0133, W, 1e-4); // kg/kg dry air
+    }
+
+    /**
+     * Validate dew point temperature calculation.
+     *
+     * <p>Inputs: humidity ratio in kg/kg dry air and pressure in Pascal. The
+     * expected output is the dew point temperature in Kelvin.</p>
+     */
+    @Test
+    void testDewPoint() {
+        double p = 101325.0; // Pa
+        double W = 0.010; // kg/kg dry air
+
+        double td = HumidAir.dewPointTemperature(W, p);
+
+        assertEquals(287.2, td, 0.5); // K
+    }
+
+    /**
+     * Validate saturated humid-air specific heat correlation.
+     *
+     * <p>Input temperature is given in Kelvin and the specific heat is returned
+     * in kJ∕(kg·K).</p>
+     */
+    @Test
+    void testCairSat() {
+        double cp = HumidAir.cairSat(298.15); // K
+
+        assertEquals(4.17, cp, 0.05); // kJ/(kg*K)
+    }
+}


### PR DESCRIPTION
## Summary
- document humid air equations used in the new utility
- link mathematics documentation from the wiki index

## Testing
- `mvn -Dtest=neqsim.thermo.util.humidair.HumidAirTest test`
- `mvn checkstyle:check`


------
https://chatgpt.com/codex/tasks/task_e_687226c88658832dbe67badba99023e8