### PR TITLE
Add Broyden solver and tolerances

### DIFF
--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnTest.java
@@ -307,4 +307,23 @@ public class DistillationColumnTest {
      * + " C");
      */
   }
+
+  @Test
+  public void testBroydenSolver() {
+    neqsim.thermo.system.SystemInterface simpleSystem =
+        new neqsim.thermo.system.SystemSrkEos(298.15, 5.0);
+    simpleSystem.addComponent("methane", 1.0);
+    simpleSystem.addComponent("ethane", 1.0);
+    simpleSystem.createDatabase(true);
+    simpleSystem.setMixingRule("classic");
+
+    Stream feed = new Stream("feed", simpleSystem);
+    feed.run();
+
+    DistillationColumn column = new DistillationColumn("test column", 1, true, true);
+    column.addFeedStream(feed, 1);
+    column.runBroyden();
+
+    assertEquals(true, column.solved());
+  }
 }


### PR DESCRIPTION
## Summary
- expose tolerances for temperature, mass and enthalpy convergence
- check mass and energy balance during iterations
- add new `runBroyden` method with simple mixing acceleration
- test new solver implementation

## Testing
- `./mvnw -q -Dtest=DistillationColumnTest test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687237152274832db04a9dd7eda89ed5