### PR TITLE
Add orifice flow meter calculations

### DIFF
--- a/docs/wiki/flow_meter_models.md
+++ b/docs/wiki/flow_meter_models.md
@@ -1,0 +1,27 @@
+# Flow meter models
+
+This page documents the equations implemented in the `Orifice` equipment for
+computing flow through differential pressure meters. All variables are in SI
+units.
+
+## Orifice plate
+
+The discharge coefficient $C$ is calculated with the Reader&ndash;Harris/Gallagher
+correlation as implemented in ISO&nbsp;5167:
+
+$$
+C = 0.5961 + 0.0261\beta^2 - 0.216\beta^8 + 0.000521\left(\frac{10^6\beta}{Re_D}\right)^{0.7}
+    +(0.0188 + 0.0063A)\beta^{3.5}\left(\frac{10^6}{Re_D}\right)^{0.3}
+    +(0.043 + 0.080e^{-10L_1}-0.123e^{-7L_1})(1-0.11A)\frac{\beta^4}{1-\beta^4}
+    -0.031(M_2' -0.8M_2'^{1.1})\beta^{1.3}
+$$
+
+The expansibility factor is
+$$
+\epsilon = 1 - (0.351 +0.256\beta^4 +0.93\beta^8)\left[1-\left(\frac{P_2}{P_1}\right)^{1/\kappa}\right]
+$$
+
+The mass flow rate is obtained iteratively from
+$$
+ m = \left(\tfrac{\pi D^2\beta^2}{4}\right) C \epsilon \frac{\sqrt{2\rho(P_1-P_2)}}{\sqrt{1-\beta^4}}.
+$$

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -14,3 +14,4 @@ This folder holds additional documentation for the NeqSim project. Below are use
 - [JUnit test overview](test-overview.md)
 - [Distillation column algorithm](distillation_column.md)
 - [Humid air mathematics](humid_air_math.md)
+- [Flow meter models](flow_meter_models.md)

--- a/src/main/java/neqsim/process/equipment/diffpressure/Orifice.java
+++ b/src/main/java/neqsim/process/equipment/diffpressure/Orifice.java
@@ -193,6 +193,42 @@ public class Orifice extends TwoPortEquipment {
     return Do / D;
   }
 
+  /**
+   * Calculates the mass flow rate through an orifice plate using the ISO 5167
+   * formulation.
+   *
+   * <p>Inputs and output are all in SI units. The method iterates the
+   * Reader-Harris/Gallagher discharge coefficient until convergence.</p>
+   *
+   * @param D upstream internal pipe diameter in meters
+   * @param Do orifice diameter in meters
+   * @param P1 upstream static pressure in Pa
+   * @param P2 downstream static pressure in Pa
+   * @param rho fluid density in kg/m3 at P1
+   * @param mu fluid viscosity in Pa*s at P1
+   * @param k isentropic exponent of the fluid
+   * @param taps pressure tap type ("corner", "flange", "D", or "D/2")
+   * @return mass flow rate in kg/s
+   */
+  public static double calculateMassFlowRate(double D, double Do, double P1, double P2,
+      double rho, double mu, double k, String taps) {
+    double m = 1.0;
+    for (int i = 0; i < 50; i++) {
+      double C = calculateDischargeCoefficient(D, Do, rho, mu, m, taps);
+      double epsilon = calculateExpansibility(D, Do, P1, P2, k);
+      double beta = calculateBetaRatio(D, Do);
+      double beta2 = beta * beta;
+      double mCalc = 0.25 * Math.PI * Do * Do * C * epsilon
+          * Math.sqrt(2.0 * rho * (P1 - P2) / (1.0 - beta2 * beta2));
+      if (Math.abs(mCalc - m) / m < 1e-8) {
+        m = mCalc;
+        break;
+      }
+      m = mCalc;
+    }
+    return m;
+  }
+
   /** {@inheritDoc} */
   @Override
   public void run(UUID uuid) {

--- a/src/test/java/neqsim/process/equipment/diffpressure/OrificeTest.java
+++ b/src/test/java/neqsim/process/equipment/diffpressure/OrificeTest.java
@@ -1,5 +1,6 @@
 package neqsim.process.equipment.diffpressure;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.processmodel.ProcessSystem;
@@ -37,5 +38,19 @@ public class OrificeTest {
 
     // Output the pressure after the orifice
     System.out.println("Pressure out of orifice: " + stream2.getPressure("bara") + " bara");
+  }
+
+  @Test
+  void testOrificeCorrelation() {
+    double C = Orifice.calculateDischargeCoefficient(0.07391, 0.0222, 1.165, 1.85E-5, 0.12,
+        "flange");
+    Assertions.assertEquals(0.5990326277, C, 1e-6);
+
+    double eps = Orifice.calculateExpansibility(0.0739, 0.0222, 1.0E5, 9.9E4, 1.4);
+    Assertions.assertEquals(0.9974739057, eps, 1e-9);
+
+    double m = Orifice.calculateMassFlowRate(0.07366, 0.05, 200000.0, 183000.0, 999.1, 0.0011,
+        1.33, "D");
+    Assertions.assertEquals(7.702338, m, 1e-6);
   }
 }


### PR DESCRIPTION
## Summary
- implement iterative mass flow solver and expose in Orifice
- add unit tests for discharge coefficient, expansibility and flow solver
- document flow meter equations in new wiki page

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6872386e8d54832da73d12635b40fc79