### PR TITLE
Add air cooler unit using humid air

### DIFF
--- a/docs/wiki/air_cooler.md
+++ b/docs/wiki/air_cooler.md
@@ -1,0 +1,21 @@
+# Air cooler unit operation
+
+The `AirCooler` is a simple process unit for estimating the amount of cooling air needed when a process stream is cooled by ambient air. The calculation makes use of the humid air utility in NeqSim to evaluate the enthalpy rise of the air between the inlet and outlet temperature.
+
+For a given inlet temperature, outlet temperature and relative humidity of the air, the mass flow of dry air is obtained from
+
+\[
+\dot m_{air} = \frac{Q}{h_{out}-h_{in}}
+\]
+
+where `Q` is the heat removed from the process stream in watt and `h_{in}` and `h_{out}` are the specific humid–air enthalpies in kJ per kg dry air. The volumetric flow is calculated from the ideal–gas relation at the inlet conditions.
+
+Basic usage:
+
+```java
+AirCooler cooler = new AirCooler("air cooler", stream);
+cooler.setOutTemperature(40.0, "C");
+cooler.setAirInletTemperature(20.0, "C");
+cooler.setAirOutletTemperature(30.0, "C");
+cooler.setRelativeHumidity(0.5);
+```

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -15,3 +15,4 @@ This folder holds additional documentation for the NeqSim project. Below are use
 - [Distillation column algorithm](distillation_column.md)
 - [Humid air mathematics](humid_air_math.md)
 - [Flow meter models](flow_meter_models.md)
+- [Air cooler unit operation](air_cooler.md)

--- a/src/main/java/neqsim/process/equipment/heatexchanger/AirCooler.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/AirCooler.java
@@ -1,0 +1,77 @@
+package neqsim.process.equipment.heatexchanger;
+
+import java.util.UUID;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.util.humidair.HumidAir;
+
+/**
+ * Air cooler using humid air properties to estimate required air flow.
+ */
+public class AirCooler extends Cooler {
+  private static final long serialVersionUID = 1000L;
+
+  private double airInletTemperature = 298.15; // K
+  private double airOutletTemperature = 308.15; // K
+  private double relativeHumidity = 0.6; // [-]
+  private double pressure = 101325.0; // Pa
+
+  private double airMassFlow = 0.0; // kg dry air/s
+  private double airVolumeFlow = 0.0; // m3/s at inlet conditions
+
+  public AirCooler(String name) {
+    super(name);
+  }
+
+  public AirCooler(String name, StreamInterface inStream) {
+    super(name, inStream);
+  }
+
+  public void setAirInletTemperature(double temperature, String unit) {
+    airInletTemperature = unit.equalsIgnoreCase("C") ? temperature + 273.15 : temperature;
+  }
+
+  public void setAirOutletTemperature(double temperature, String unit) {
+    airOutletTemperature = unit.equalsIgnoreCase("C") ? temperature + 273.15 : temperature;
+  }
+
+  public void setRelativeHumidity(double rh) {
+    relativeHumidity = rh;
+  }
+
+  public void setPressure(double pressure) {
+    this.pressure = pressure;
+  }
+
+  public double getAirMassFlow() {
+    return airMassFlow;
+  }
+
+  public double getAirVolumeFlow() {
+    return airVolumeFlow;
+  }
+
+  private void calcAirFlow(double duty) {
+    double W = HumidAir.humidityRatioFromRH(airInletTemperature, pressure, relativeHumidity);
+    double hin = HumidAir.enthalpy(airInletTemperature, W); // kJ/kg dry air
+    double hout = HumidAir.enthalpy(airOutletTemperature, W); // kJ/kg dry air
+    double dh = hout - hin; // kJ/kg dry air
+    if (Math.abs(dh) < 1e-6) {
+      airMassFlow = 0.0;
+      airVolumeFlow = 0.0;
+      return;
+    }
+    airMassFlow = duty / (dh * 1000.0); // kg dry air/s
+    // volume per kg dry air at inlet conditions
+    double Mda = 28.965e-3; // kg/mol
+    double Mw = 18.01528e-3; // kg/mol
+    double volumePerKgDryAir = ((1.0 / Mda) + (W / Mw)) * 8.314 * airInletTemperature / pressure;
+    airVolumeFlow = airMassFlow * volumePerKgDryAir;
+  }
+
+  @Override
+  public void run(UUID id) {
+    super.run(id);
+    double duty = -getDuty();
+    calcAirFlow(duty);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/heatexchanger/AirCoolerTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/AirCoolerTest.java
@@ -1,0 +1,44 @@
+package neqsim.process.equipment.heatexchanger;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Simple tests for the AirCooler unit operation.
+ */
+public class AirCoolerTest {
+  static neqsim.thermo.system.SystemInterface testSystem = null;
+  ProcessSystem processOps = null;
+  AirCooler airCooler = null;
+
+  @BeforeEach
+  public void setUp() {
+    testSystem = new SystemSrkEos(353.15, 10.0);
+    testSystem.addComponent("methane", 100.0);
+    Stream inlet = new Stream("inlet", testSystem);
+    inlet.setFlowRate(1.0, "MSm3/day");
+    inlet.setPressure(10.0, "bara");
+    inlet.setTemperature(80.0, "C");
+
+    airCooler = new AirCooler("air cooler", inlet);
+    airCooler.setOutTemperature(40.0, "C");
+    airCooler.setAirInletTemperature(20.0, "C");
+    airCooler.setAirOutletTemperature(30.0, "C");
+    airCooler.setRelativeHumidity(0.5);
+
+    processOps = new ProcessSystem();
+    processOps.add(inlet);
+    processOps.add(airCooler);
+    processOps.run();
+  }
+
+  @Test
+  public void testAirFlowIsPositive() {
+    assertTrue(airCooler.getAirMassFlow() > 0.0);
+    assertTrue(airCooler.getAirVolumeFlow() > 0.0);
+  }
+}


### PR DESCRIPTION
## Summary
- add `AirCooler` unit op that calculates required air flow from humid air properties
- document usage in `docs/wiki/air_cooler.md` and index
- test that air flow calculation runs

## Testing
- `mvn test` *(fails: Network is unreachable)*
- `mvn checkstyle:check` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687268a089c8832dac99bc1a5867d98d