### PR TITLE
Add flare unit operation with heat and emissions

### DIFF
--- a/src/main/java/neqsim/process/equipment/EquipmentEnum.java
+++ b/src/main/java/neqsim/process/equipment/EquipmentEnum.java
@@ -8,7 +8,7 @@ package neqsim.process.equipment;
  * @author esol
  */
 public enum EquipmentEnum {
-  Stream, ThrottlingValve, Compressor, Pump, Separator, HeatExchanger, Cooler, Heater, Mixer, Splitter, Reactor, Column, ThreePhaseSeparator, Recycle, Ejector, GORfitter, Adjuster, SetPoint, FlowRateAdjuster, Calculator, Expander, SimpleTEGAbsorber, Tank, ComponentSplitter, ReservoirCVDsim, ReservoirDiffLibsim, VirtualStream, ReservoirTPsim, SimpleReservoir, Manifold;
+  Stream, ThrottlingValve, Compressor, Pump, Separator, HeatExchanger, Cooler, Heater, Mixer, Splitter, Reactor, Column, ThreePhaseSeparator, Recycle, Ejector, GORfitter, Adjuster, SetPoint, FlowRateAdjuster, Calculator, Expander, SimpleTEGAbsorber, Tank, ComponentSplitter, ReservoirCVDsim, ReservoirDiffLibsim, VirtualStream, ReservoirTPsim, SimpleReservoir, Manifold, Flare;
 
   /** {@inheritDoc} */
   @Override

--- a/src/main/java/neqsim/process/equipment/EquipmentFactory.java
+++ b/src/main/java/neqsim/process/equipment/EquipmentFactory.java
@@ -28,6 +28,7 @@ import neqsim.process.equipment.util.GORfitter;
 import neqsim.process.equipment.util.Recycle;
 import neqsim.process.equipment.util.SetPoint;
 import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.equipment.flare.Flare;
 
 /**
  * <p>
@@ -116,6 +117,8 @@ public class EquipmentFactory {
         return new SimpleReservoir(name);
       case "manifold":
         return new Manifold(name);
+      case "flare":
+        return new Flare(name);
 
       // Add other equipment types here
       default:

--- a/src/main/java/neqsim/process/equipment/flare/Flare.java
+++ b/src/main/java/neqsim/process/equipment/flare/Flare.java
@@ -1,0 +1,113 @@
+package neqsim.process.equipment.flare;
+
+import java.util.UUID;
+import neqsim.process.equipment.TwoPortEquipment;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.util.unit.PowerUnit;
+
+/**
+ * Flare unit operation for combustion of a process stream.
+ */
+public class Flare extends TwoPortEquipment {
+  private static final long serialVersionUID = 1000;
+
+  private double heatDuty = 0.0; // J/s
+  private double co2Emission = 0.0; // kg/s
+
+  /**
+   * Default constructor.
+   * 
+   * @param name name of the flare
+   */
+  public Flare(String name) {
+    super(name);
+  }
+
+  /**
+   * Constructor setting inlet stream.
+   * 
+   * @param name name of flare
+   * @param inletStream inlet stream
+   */
+  public Flare(String name, StreamInterface inletStream) {
+    this(name);
+    setInletStream(inletStream);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setInletStream(StreamInterface stream) {
+    this.inStream = stream;
+    this.outStream = new Stream(stream.getName() + "_flareout", stream.getFluid().clone());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void run(UUID id) {
+    SystemInterface thermoSystem = inStream.getThermoSystem().clone();
+    double flowSm3sec = inStream.getFlowRate("Sm3/sec");
+    heatDuty = inStream.LCV() * flowSm3sec;
+
+    double molesTotalPerSec = inStream.getFlowRate("mole/sec");
+    double molesCarbonPerSec = 0.0;
+    for (int i = 0; i < thermoSystem.getNumberOfComponents(); i++) {
+      double moleFrac = thermoSystem.getComponent(i).getz();
+      double molesCompPerSec = moleFrac * molesTotalPerSec;
+      double nC = thermoSystem.getComponent(i).getElements().getNumberOfElements("C");
+      molesCarbonPerSec += molesCompPerSec * nC;
+    }
+    co2Emission = molesCarbonPerSec * 44.01e-3; // kg/s
+
+    outStream.setThermoSystem(thermoSystem);
+    setCalculationIdentifier(id);
+  }
+
+  /**
+   * Get heat released from flare.
+   * 
+   * @return heat duty in W
+   */
+  public double getHeatDuty() {
+    return heatDuty;
+  }
+
+  /**
+   * Get heat released in desired unit.
+   * 
+   * @param unit engineering unit, e.g. "MW"
+   * @return heat duty in specified unit
+   */
+  public double getHeatDuty(String unit) {
+    PowerUnit conv = new PowerUnit(heatDuty, "W");
+    return conv.getValue(unit);
+  }
+
+  /**
+   * Get CO2 emissions in kg/s.
+   * 
+   * @return CO2 emission rate
+   */
+  public double getCO2Emission() {
+    return co2Emission;
+  }
+
+  /**
+   * Get CO2 emissions in specified unit.
+   * Supported units: kg/sec, kg/hr, kg/day
+   * 
+   * @param unit desired unit
+   * @return emission in specified unit
+   */
+  public double getCO2Emission(String unit) {
+    switch (unit) {
+      case "kg/hr":
+        return co2Emission * 3600.0;
+      case "kg/day":
+        return co2Emission * 3600.0 * 24.0;
+      default:
+        return co2Emission;
+    }
+  }
+}

--- a/src/test/java/neqsim/process/equipment/flare/FlareTest.java
+++ b/src/test/java/neqsim/process/equipment/flare/FlareTest.java
@@ -1,0 +1,34 @@
+package neqsim.process.equipment.flare;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Test of the Flare unit operation. */
+public class FlareTest {
+  ProcessSystem processOps;
+  Flare flare;
+
+  @BeforeEach
+  public void setUp() {
+    SystemSrkEos testSystem = new SystemSrkEos(298.15, 1.0);
+    testSystem.addComponent("methane", 1.0);
+    Stream gasStream = new Stream("gas stream", testSystem);
+    gasStream.setFlowRate(1.0, "MSm3/day");
+
+    processOps = new ProcessSystem();
+    flare = new Flare("flare", gasStream);
+    processOps.add(gasStream);
+    processOps.add(flare);
+    processOps.run();
+  }
+
+  @Test
+  public void testFlareCalculations() {
+    assertTrue(flare.getHeatDuty() > 0.0);
+    assertTrue(flare.getCO2Emission() > 0.0);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `Flare` unit operation to model flaring of a process stream
- calculate heat release and CO2 emissions
- register flare in `EquipmentEnum` and `EquipmentFactory`
- add unit test for flare operation

## Testing
- `mvn -Dtest=FlareTest test`
- `mvn checkstyle:check`

------
https://chatgpt.com/codex/tasks/task_e_68726764fae8832d8cc4815960c3e975