### PR TITLE
Add membrane separator unit

### DIFF
--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -15,3 +15,4 @@ This folder holds additional documentation for the NeqSim project. Below are use
 - [Distillation column algorithm](distillation_column.md)
 - [Humid air mathematics](humid_air_math.md)
 - [Flow meter models](flow_meter_models.md)
+- [Membrane separation](membrane_separation.md)

--- a/docs/wiki/membrane_separation.md
+++ b/docs/wiki/membrane_separation.md
@@ -1,0 +1,31 @@
+# Membrane separation
+
+This page outlines the basic model implemented in the `MembraneSeparator` unit. The unit is intended for simple simulations of gas separation membranes or pervaporation modules used in purification and CO2 capture.
+
+## Flux model
+For each component $i$ a constant permeate fraction $f_i$ can be specified. The molar amount transferred to the permeate side is
+$$
+N_i^{\text{perm}} = f_i N_i^{\text{feed}}
+$$
+where $N_i^{\text{feed}}$ is the molar amount in the feed stream. Components without a specified fraction use a global default value.
+
+A more rigorous model could employ Fick's law of diffusion through the membrane
+$$
+J_i = P_i \left(p_{i,\text{feed}} - p_{i,\text{perm}}\right)
+$$
+where $P_i$ is the permeability of component $i$ and $p_i$ are partial pressures.
+The separator can now perform this calculation mode when permeabilities and a membrane area are supplied.
+
+## Usage
+```java
+MembraneSeparator mem = new MembraneSeparator("mem", feedStream);
+mem.setDefaultPermeateFraction(0.1); // 10 % of each component permeates
+mem.setPermeateFraction("CO2", 0.5); // override CO2 fraction
+```
+// Alternative using permeability coefficients
+mem.clearPermeateFractions();
+mem.setMembraneArea(5.0); // m^2
+mem.setPermeability("CO2", 5e-6); // mol/(m2*s*Pa)
+mem.setPermeability("methane", 1e-6);
+```
+After running the process, the permeate and retentate streams can be obtained via `getPermeateStream()` and `getRetentateStream()`.

--- a/src/main/java/neqsim/process/equipment/membrane/MembraneSeparator.java
+++ b/src/main/java/neqsim/process/equipment/membrane/MembraneSeparator.java
@@ -1,0 +1,151 @@
+package neqsim.process.equipment.membrane;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Simple membrane separation unit with one inlet stream and two outlet streams
+ * (retentate and permeate). Each component can be assigned a permeate fraction
+ * representing the fraction of that component transported to the permeate side.
+ */
+public class MembraneSeparator extends ProcessEquipmentBaseClass {
+  private static final long serialVersionUID = 1000;
+  static Logger logger = LogManager.getLogger(MembraneSeparator.class);
+
+  private StreamInterface inletStream;
+  private StreamInterface permeateStream;
+  private StreamInterface retentateStream;
+  private final Map<String, Double> permeateFractions = new HashMap<>();
+  private final Map<String, Double> permeabilities = new HashMap<>();
+  private double defaultPermeateFraction = 0.0;
+  private double membraneArea = 0.0; // m2
+
+  public MembraneSeparator(String name) {
+    super(name);
+  }
+
+  public MembraneSeparator(String name, StreamInterface inletStream) {
+    this(name);
+    setInletStream(inletStream);
+  }
+
+  public void setInletStream(StreamInterface inletStream) {
+    this.inletStream = inletStream;
+    this.permeateStream = new Stream(getName() + " permeate", inletStream.getThermoSystem().clone());
+    this.retentateStream = new Stream(getName() + " retentate", inletStream.getThermoSystem().clone());
+  }
+
+  public StreamInterface getPermeateStream() {
+    return permeateStream;
+  }
+
+  public StreamInterface getRetentateStream() {
+    return retentateStream;
+  }
+
+  /**
+   * Set membrane area used for permeability calculations.
+   *
+   * @param area membrane area in m^2
+   */
+  public void setMembraneArea(double area) {
+    this.membraneArea = Math.max(0.0, area);
+  }
+
+  /**
+   * Specify permeability coefficient for a component.
+   *
+   * @param component component name
+   * @param permeability permeability in mol/(m2*s*Pa)
+   */
+  public void setPermeability(String component, double permeability) {
+    permeabilities.put(component, Math.max(0.0, permeability));
+  }
+
+  /**
+   * Remove any permeate fractions set previously.
+   */
+  public void clearPermeateFractions() {
+    permeateFractions.clear();
+    defaultPermeateFraction = 0.0;
+  }
+
+  /**
+   * Set a global permeate fraction used for all components not explicitly set.
+   *
+   * @param fraction permeate fraction (0-1)
+   */
+  public void setDefaultPermeateFraction(double fraction) {
+    this.defaultPermeateFraction = Math.max(0.0, Math.min(1.0, fraction));
+  }
+
+  /**
+   * Specify permeate fraction for a component.
+   *
+   * @param component component name
+   * @param fraction permeate fraction (0-1)
+   */
+  public void setPermeateFraction(String component, double fraction) {
+    permeateFractions.put(component, Math.max(0.0, Math.min(1.0, fraction)));
+  }
+
+  @Override
+  public boolean needRecalculation() {
+    return true;
+  }
+
+  @Override
+  public void run(UUID id) {
+    try {
+      retentateStream.setThermoSystem(inletStream.getThermoSystem().clone());
+      permeateStream.setThermoSystem(inletStream.getThermoSystem().clone());
+
+      int comps = inletStream.getThermoSystem().getPhase(0).getNumberOfComponents();
+      for (int i = 0; i < comps; i++) {
+        String name = inletStream.getThermoSystem().getPhase(0).getComponent(i).getName();
+        double moles = inletStream.getThermoSystem().getPhase(0).getComponent(i).getNumberOfmoles();
+
+        double molesPerm = 0.0;
+        if (!permeabilities.isEmpty() && membraneArea > 0.0) {
+          double perm = permeabilities.getOrDefault(name, 0.0);
+          double xFeed = inletStream.getThermoSystem().getPhase(0).getComponent(i).getx();
+          double partialFeed = xFeed * inletStream.getThermoSystem().getPressure();
+          molesPerm = perm * membraneArea * partialFeed;
+          if (molesPerm > moles) {
+            molesPerm = moles;
+          }
+        } else {
+          double frac = permeateFractions.getOrDefault(name, defaultPermeateFraction);
+          molesPerm = moles * frac;
+        }
+
+        retentateStream.getThermoSystem().addComponent(name, -molesPerm);
+        permeateStream.getThermoSystem().addComponent(name, molesPerm);
+      }
+
+      ThermodynamicOperations opsRet = new ThermodynamicOperations(retentateStream.getThermoSystem());
+      opsRet.TPflash();
+      ThermodynamicOperations opsPerm = new ThermodynamicOperations(permeateStream.getThermoSystem());
+      opsPerm.TPflash();
+
+      retentateStream.setCalculationIdentifier(id);
+      permeateStream.setCalculationIdentifier(id);
+      setCalculationIdentifier(id);
+    } catch (Exception ex) {
+      logger.error("Error in membrane separator", ex);
+    }
+  }
+
+  @Override
+  public void runTransient(double dt, UUID id) {
+    run(id);
+    increaseTime(dt);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/membrane/MembraneSeparatorTest.java
+++ b/src/test/java/neqsim/process/equipment/membrane/MembraneSeparatorTest.java
@@ -1,0 +1,81 @@
+package neqsim.process.equipment.membrane;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Unit test for MembraneSeparator. */
+class MembraneSeparatorTest extends neqsim.NeqSimTest {
+  ProcessSystem processOps;
+  MembraneSeparator membrane;
+  StreamInterface inlet;
+
+  @BeforeEach
+  public void setUp() {
+    SystemSrkEos system = new SystemSrkEos(298.0, 10.0);
+    system.addComponent("methane", 90.0);
+    system.addComponent("CO2", 10.0);
+    system.setMixingRule(2);
+
+    inlet = new Stream("feed", system);
+    inlet.setFlowRate(1.0, "kg/sec");
+
+    membrane = new MembraneSeparator("membrane", inlet);
+    membrane.setPermeateFraction("CO2", 0.5);
+    membrane.setDefaultPermeateFraction(0.1);
+
+    processOps = new ProcessSystem();
+    processOps.add(inlet);
+    processOps.add(membrane);
+    processOps.add(membrane.getPermeateStream());
+    processOps.add(membrane.getRetentateStream());
+  }
+
+  @Test
+  void massBalance() {
+    processOps.run();
+    double in = inlet.getMolarRate();
+    double out = membrane.getPermeateStream().getMolarRate()
+        + membrane.getRetentateStream().getMolarRate();
+    assertEquals(in, out, 1e-6);
+  }
+
+  @Test
+  void compositionChange() {
+    processOps.run();
+    double xCO2Feed = inlet.getFluid().getPhase(0).getComponent("CO2").getz();
+    double xCO2Perm = membrane.getPermeateStream().getFluid().getPhase(0).getComponent("CO2").getz();
+    double xCO2Ret = membrane.getRetentateStream().getFluid().getPhase(0).getComponent("CO2").getz();
+    // Permeate should have higher CO2 fraction
+    assertEquals(true, xCO2Perm > xCO2Feed);
+    // Retentate should have lower CO2 fraction
+    assertEquals(true, xCO2Ret < xCO2Feed);
+  }
+
+  @Test
+  void permeabilityModel() {
+    MembraneSeparator mem2 = new MembraneSeparator("perm", inlet);
+    mem2.clearPermeateFractions();
+    mem2.setMembraneArea(10.0);
+    mem2.setPermeability("CO2", 5e-6);
+    mem2.setPermeability("methane", 1e-6);
+
+    ProcessSystem proc = new ProcessSystem();
+    proc.add(inlet);
+    proc.add(mem2);
+    proc.add(mem2.getPermeateStream());
+    proc.add(mem2.getRetentateStream());
+    proc.run();
+
+    double in = inlet.getMolarRate();
+    double out = mem2.getPermeateStream().getMolarRate() + mem2.getRetentateStream().getMolarRate();
+    assertEquals(in, out, 1e-6);
+    double xCO2Perm = mem2.getPermeateStream().getFluid().getPhase(0).getComponent("CO2").getx();
+    double xCO2Feed = inlet.getFluid().getPhase(0).getComponent("CO2").getx();
+    assertEquals(true, xCO2Perm > xCO2Feed);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `MembraneSeparator` equipment
- test membrane separator mass balance and composition shift
- document flux model for membranes
- link doc from wiki index
- add optional permeability-based calculation

## Testing
- `mvn test` *(fails: network unreachable)*
- `mvn checkstyle:check` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687268129618832da04fb78139b15894