### PR TITLE
Improve flow regime selection

### DIFF
--- a/src/main/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrills.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrills.java
@@ -22,6 +22,16 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
 public class PipeBeggsAndBrills extends Pipeline {
   private static final long serialVersionUID = 1001;
 
+  /** Flow regimes available in Beggs and Brill correlations. */
+  public enum FlowRegime {
+    SEGREGATED,
+    INTERMITTENT,
+    DISTRIBUTED,
+    TRANSITION,
+    SINGLE_PHASE,
+    UNKNOWN
+  }
+
   int iteration;
 
   private double nominalDiameter;
@@ -53,7 +63,7 @@ public class PipeBeggsAndBrills extends Pipeline {
   private boolean runIsothermal = true;
 
   // Flow pattern of the fluid in the pipe
-  private String regime;
+  private FlowRegime regime;
 
   // Volume fraction of liquid in the input mixture
   private double inputVolumeFractionLiquid;
@@ -131,7 +141,7 @@ public class PipeBeggsAndBrills extends Pipeline {
   private List<Double> pressureProfile;
   private List<Double> temperatureProfile;
   private List<Double> pressureDropProfile;
-  private List<String> flowRegimeProfile;
+  private List<FlowRegime> flowRegimeProfile;
 
   private List<Double> liquidSuperficialVelocityProfile;
   private List<Double> gasSuperficialVelocityProfile;
@@ -475,9 +485,9 @@ public class PipeBeggsAndBrills extends Pipeline {
    * calcFlowRegime.
    * </p>
    *
-   * @return a {@link java.lang.String} object
+   * @return the determined flow regime
    */
-  public String calcFlowRegime() {
+  public FlowRegime calcFlowRegime() {
     // Calc input volume fraction
     area = (Math.PI / 4.0) * Math.pow(insideDiameter, 2.0);
     if (system.getNumberOfPhases() != 1) {
@@ -499,12 +509,12 @@ public class PipeBeggsAndBrills extends Pipeline {
         supGasVel = system.getPhase(0).getFlowRate("ft3/sec") / area;
         supMixVel = supGasVel;
         inputVolumeFractionLiquid = 0.0;
-        regime = "Single Phase";
+        regime = FlowRegime.SINGLE_PHASE;
       } else {
         supLiquidVel = system.getPhase(1).getFlowRate("ft3/sec") / area;
         supMixVel = supLiquidVel;
         inputVolumeFractionLiquid = 1.0;
-        regime = "Single Phase";
+        regime = FlowRegime.SINGLE_PHASE;
       }
     }
 
@@ -517,24 +527,24 @@ public class PipeBeggsAndBrills extends Pipeline {
     double L3 = 0.1 * Math.pow(inputVolumeFractionLiquid, -1.4516);
     double L4 = 0.5 * Math.pow(inputVolumeFractionLiquid, -6.738);
 
-    if (regime != "Single Phase") {
+    if (regime != FlowRegime.SINGLE_PHASE) {
       if ((inputVolumeFractionLiquid < 0.01 && mixtureFroudeNumber < L1)
           || (inputVolumeFractionLiquid >= 0.01 && mixtureFroudeNumber < L2)) {
-        regime = "SEGREGATED";
+        regime = FlowRegime.SEGREGATED;
       } else if ((inputVolumeFractionLiquid < 0.4 && inputVolumeFractionLiquid >= 0.01
           && mixtureFroudeNumber <= L1 && mixtureFroudeNumber > L3)
           || (inputVolumeFractionLiquid >= 0.4 && mixtureFroudeNumber <= L4
               && mixtureFroudeNumber > L3)) {
-        regime = "INTERMITTENT";
+        regime = FlowRegime.INTERMITTENT;
       } else if ((inputVolumeFractionLiquid < 0.4 && mixtureFroudeNumber >= L4)
           || (inputVolumeFractionLiquid >= 0.4 && mixtureFroudeNumber > L4)) {
-        regime = "DISTRIBUTED";
+        regime = FlowRegime.DISTRIBUTED;
       } else if (mixtureFroudeNumber > L2 && mixtureFroudeNumber < L3) {
-        regime = "TRANSITION";
+        regime = FlowRegime.TRANSITION;
       } else if (inputVolumeFractionLiquid < 0.1 || inputVolumeFractionLiquid > 0.9) {
-        regime = "INTERMITTENT";
+        regime = FlowRegime.INTERMITTENT;
       } else if (mixtureFroudeNumber > 110) {
-        regime = "INTERMITTENT";
+        regime = FlowRegime.INTERMITTENT;
       } else {
         throw new RuntimeException(new neqsim.util.exception.InvalidOutputException(
             "PipeBeggsAndBrills", "run: calcFlowRegime", "FlowRegime", "Flow regime is not found"));
@@ -559,21 +569,21 @@ public class PipeBeggsAndBrills extends Pipeline {
 
     double BThetta;
 
-    if (regime == "SEGREGATED") {
+    if (regime == FlowRegime.SEGREGATED) {
       El = 0.98 * Math.pow(inputVolumeFractionLiquid, 0.4846)
           / Math.pow(mixtureFroudeNumber, 0.0868);
-    } else if (regime == "INTERMITTENT") {
+    } else if (regime == FlowRegime.INTERMITTENT) {
       El = 0.845 * Math.pow(inputVolumeFractionLiquid, 0.5351)
           / (Math.pow(mixtureFroudeNumber, 0.0173));
-    } else if (regime == "DISTRIBUTED") {
+    } else if (regime == FlowRegime.DISTRIBUTED) {
       El = 1.065 * Math.pow(inputVolumeFractionLiquid, 0.5824)
           / (Math.pow(mixtureFroudeNumber, 0.0609));
-    } else if (regime == "TRANSITION") {
+    } else if (regime == FlowRegime.TRANSITION) {
       El = A * 0.98 * Math.pow(inputVolumeFractionLiquid, 0.4846)
           / Math.pow(mixtureFroudeNumber, 0.0868)
           + B * 0.845 * Math.pow(inputVolumeFractionLiquid, 0.5351)
               / (Math.pow(mixtureFroudeNumber, 0.0173));
-    } else if (regime == "Single Phase") {
+    } else if (regime == FlowRegime.SINGLE_PHASE) {
       if (inputVolumeFractionLiquid < 0.1) {
         El = inputVolumeFractionLiquid;
       } else {
@@ -581,7 +591,7 @@ public class PipeBeggsAndBrills extends Pipeline {
       }
     }
 
-    if (regime != "Single Phase") {
+    if (regime != FlowRegime.SINGLE_PHASE) {
       double SG;
       if (system.getNumberOfPhases() == 3) {
         mixtureOilMassFraction = system.getPhase(1).getFlowRate("kg/hr")
@@ -620,15 +630,15 @@ public class PipeBeggsAndBrills extends Pipeline {
       double betta = 0;
 
       if (elevation > 0) {
-        if (regime == "SEGREGATED") {
+        if (regime == FlowRegime.SEGREGATED) {
           betta = (1 - inputVolumeFractionLiquid)
               * Math.log(0.011 * Math.pow(Nvl, 3.539) / (Math.pow(inputVolumeFractionLiquid, 3.768)
                   * Math.pow(mixtureFroudeNumber, 1.614)));
-        } else if (regime == "INTERMITTENT") {
+        } else if (regime == FlowRegime.INTERMITTENT) {
           betta = (1 - inputVolumeFractionLiquid)
               * Math.log(2.96 * Math.pow(inputVolumeFractionLiquid, 0.305)
                   * Math.pow(mixtureFroudeNumber, 0.0978) / (Math.pow(Nvl, 0.4473)));
-        } else if (regime == "DISTRIBUTED") {
+        } else if (regime == FlowRegime.DISTRIBUTED) {
           betta = 0;
         }
       } else {
@@ -675,7 +685,7 @@ public class PipeBeggsAndBrills extends Pipeline {
     double muNoSlip = 0;
 
     if (system.getNumberOfPhases() != 1) {
-      if (regime != "Single Phase") {
+      if (regime != FlowRegime.SINGLE_PHASE) {
         double y = inputVolumeFractionLiquid / (Math.pow(El, 2));
         if (1 < y && y < 1.2) {
           S = Math.log(2.2 * y - 1.2);
@@ -742,7 +752,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    */
   public double calcPressureDrop() {
     convertSystemUnitToImperial();
-    regime = "unknown";
+    regime = FlowRegime.UNKNOWN;
     calcFlowRegime();
     hydrostaticPressureDrop = calcHydrostaticPressureDifference();
     frictionPressureLoss = calcFrictionPressureLoss();
@@ -1055,9 +1065,9 @@ public class PipeBeggsAndBrills extends Pipeline {
    * getFlowRegime.
    * </p>
    *
-   * @return a {@link java.lang.String} object
+   * @return flow regime
    */
-  public String getFlowRegime() {
+  public FlowRegime getFlowRegime() {
     return regime;
   }
 
@@ -1169,7 +1179,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    *
    * @return list of flow regime names
    */
-  public List<String> getFlowRegimeProfile() {
+  public List<FlowRegime> getFlowRegimeProfile() {
     return new ArrayList<>(flowRegimeProfile);
   }
 
@@ -1181,7 +1191,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    * @param index segment number
    * @return String
    */
-  public String getSegmentFlowRegime(int index) {
+  public FlowRegime getSegmentFlowRegime(int index) {
     if (index >= 0 && index < flowRegimeProfile.size()) {
       return flowRegimeProfile.get(index);
     } else {

--- a/src/test/java/neqsim/process/equipment/pipeline/BeggsAndBrillsPipeTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/BeggsAndBrillsPipeTest.java
@@ -134,7 +134,7 @@ public class BeggsAndBrillsPipeTest {
     double temperatureOut = pipe.getOutletTemperature() - 273.15;
     Assertions.assertEquals(pressureOut, 13.366143179275166, 1);
     Assertions.assertEquals(temperatureOut, 38.8, 0.1);
-    Assertions.assertEquals(pipe.getFlowRegime(), "INTERMITTENT");
+    Assertions.assertEquals(pipe.getFlowRegime(), PipeBeggsAndBrills.FlowRegime.INTERMITTENT);
     Assertions.assertEquals(pipe.getOutletSuperficialVelocity(),
         pipe.getSegmentMixtureSuperficialVelocity(pipe.getNumberOfIncrements()), 0.1);
   }
@@ -189,7 +189,7 @@ public class BeggsAndBrillsPipeTest {
     Assertions.assertEquals(pipe.getSegmentPressure(10), 34.4716898025371, 1.0);
     Assertions.assertEquals(pipe.getSegmentPressureDrop(10), 1.5468048987983438, 1.0);
     Assertions.assertEquals(pipe.getSegmentTemperature(10) - 273.15, 79.80343029302054, 1.0);
-    Assertions.assertEquals(pipe.getSegmentFlowRegime(10), "INTERMITTENT");
+    Assertions.assertEquals(pipe.getSegmentFlowRegime(10), PipeBeggsAndBrills.FlowRegime.INTERMITTENT);
     Assertions.assertEquals(pipe.getSegmentMixtureDensity(10), 224.31571593591167, 20.0);
     Assertions.assertEquals(pipe.getSegmentLiquidSuperficialVelocity(10), 3.357338501138603, 1.0);
     Assertions.assertEquals(pipe.getSegmentGasSuperficialVelocity(10), 7.109484383317198, 1.0);
@@ -255,7 +255,7 @@ public class BeggsAndBrillsPipeTest {
     Assertions.assertEquals(pipe.getSegmentPressure(0), 150, 1.0);
     Assertions.assertEquals(pipe.getSegmentPressureDrop(10), 2.9204245897598162, 1.0);
     Assertions.assertEquals(pipe.getSegmentTemperature(10) - 273.15, 75.07486781297496, 1.0);
-    Assertions.assertEquals(pipe.getSegmentFlowRegime(10), "Single Phase");
+    Assertions.assertEquals(pipe.getSegmentFlowRegime(10), PipeBeggsAndBrills.FlowRegime.SINGLE_PHASE);
     Assertions.assertEquals(pipe.getSegmentMixtureDensity(10), 73.54613545016805, 1.0);
     Assertions.assertEquals(pipe.getSegmentLiquidSuperficialVelocity(10), 0.0, 1.0);
     Assertions.assertEquals(pipe.getSegmentGasSuperficialVelocity(10), 33.85480591912372, 1.0);


### PR DESCRIPTION
## Summary
- implement FlowRegime enum in Beggs & Brill pipe model
- use enum comparisons instead of string literals
- update unit tests for new enum return types

## Testing
- `mvn -q test` *(failed: environment issue)*

------
https://chatgpt.com/codex/tasks/task_e_68732d084bd0832dafc3846cb89f1bd8