### PR TITLE
Fix string comparison bug in oil quality standard

### DIFF
--- a/src/main/java/neqsim/standards/oilquality/Standard_ASTM_D6377.java
+++ b/src/main/java/neqsim/standards/oilquality/Standard_ASTM_D6377.java
@@ -147,13 +147,13 @@ public class Standard_ASTM_D6377 extends neqsim.standards.Standard {
   /** {@inheritDoc} */
   @Override
   public double getValue(String returnParameter, String returnUnit) {
-    if (returnParameter == "RVP") {
+    if ("RVP".equals(returnParameter)) {
       double RVPlocal = getValue("RVP");
       neqsim.util.unit.PressureUnit presConversion =
           new neqsim.util.unit.PressureUnit(RVPlocal, "bara");
       return presConversion.getValue(returnUnit);
     }
-    if (returnParameter == "TVP") {
+    if ("TVP".equals(returnParameter)) {
       neqsim.util.unit.PressureUnit presConversion =
           new neqsim.util.unit.PressureUnit(getValue("TVP"), "bara");
       return presConversion.getValue(returnUnit);


### PR DESCRIPTION
## Summary
- use `.equals` for comparing return parameters in `Standard_ASTM_D6377`

## Testing
- `mvn -o test` *(fails: energy reference temperature not in valid range)*
- `mvn -o checkstyle:check` *(fails: PluginContainerException)*

------
https://chatgpt.com/codex/tasks/task_e_6873f2c8b9ec832db7bb88c0a30fb6dc