### PR TITLE
Fix profile boundary check

### DIFF
--- a/src/main/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrills.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrills.java
@@ -1329,7 +1329,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    * @return Double
    */
   public Double getSegmentLiquidSuperficialVelocity(int index) {
-    if (index >= 0 && index <= liquidSuperficialVelocityProfile.size()) {
+    if (index >= 0 && index < liquidSuperficialVelocityProfile.size()) {
       return liquidSuperficialVelocityProfile.get(index);
     } else {
       throw new IndexOutOfBoundsException("Index is out of bounds.");
@@ -1345,7 +1345,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    * @return Double
    */
   public Double getSegmentGasSuperficialVelocity(int index) {
-    if (index >= 0 && index <= gasSuperficialVelocityProfile.size()) {
+    if (index >= 0 && index < gasSuperficialVelocityProfile.size()) {
       return gasSuperficialVelocityProfile.get(index);
     } else {
       throw new IndexOutOfBoundsException("Index is out of bounds.");
@@ -1361,7 +1361,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    * @return Double
    */
   public Double getSegmentMixtureSuperficialVelocity(int index) {
-    if (index >= 0 && index <= mixtureSuperficialVelocityProfile.size()) {
+    if (index >= 0 && index < mixtureSuperficialVelocityProfile.size()) {
       return mixtureSuperficialVelocityProfile.get(index);
     } else {
       throw new IndexOutOfBoundsException("Index is out of bounds.");
@@ -1377,7 +1377,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    * @return Double
    */
   public Double getSegmentMixtureViscosity(int index) {
-    if (index >= 0 && index <= mixtureViscosityProfile.size()) {
+    if (index >= 0 && index < mixtureViscosityProfile.size()) {
       return mixtureViscosityProfile.get(index);
     } else {
       throw new IndexOutOfBoundsException("Index is out of bounds.");
@@ -1393,7 +1393,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    * @return Double
    */
   public Double getSegmentMixtureDensity(int index) {
-    if (index >= 0 && index <= mixtureDensityProfile.size()) {
+    if (index >= 0 && index < mixtureDensityProfile.size()) {
       return mixtureDensityProfile.get(index);
     } else {
       throw new IndexOutOfBoundsException("Index is out of bounds.");
@@ -1409,7 +1409,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    * @return Double
    */
   public Double getSegmentLiquidDensity(int index) {
-    if (index >= 0 && index <= liquidDensityProfile.size()) {
+    if (index >= 0 && index < liquidDensityProfile.size()) {
       return liquidDensityProfile.get(index);
     } else {
       throw new IndexOutOfBoundsException("Index is out of bounds.");
@@ -1425,7 +1425,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    * @return Double
    */
   public Double getSegmentLiquidHoldup(int index) {
-    if (index >= 0 && index <= liquidHoldupProfile.size()) {
+    if (index >= 0 && index < liquidHoldupProfile.size()) {
       return liquidHoldupProfile.get(index);
     } else {
       throw new IndexOutOfBoundsException("Index is out of bounds.");
@@ -1441,7 +1441,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    * @return Double
    */
   public Double getSegmentMixtureReynoldsNumber(int index) {
-    if (index >= 0 && index <= mixtureReynoldsNumber.size()) {
+    if (index >= 0 && index < mixtureReynoldsNumber.size()) {
       return mixtureReynoldsNumber.get(index);
     } else {
       throw new IndexOutOfBoundsException("Index is out of bounds.");
@@ -1457,7 +1457,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    * @return Double
    */
   public Double getSegmentLength(int index) {
-    if (index >= 0 && index <= lengthProfile.size()) {
+    if (index >= 0 && index < lengthProfile.size()) {
       return lengthProfile.get(index);
     } else {
       throw new IndexOutOfBoundsException("Index is out of bounds.");
@@ -1473,7 +1473,7 @@ public class PipeBeggsAndBrills extends Pipeline {
    * @return Double
    */
   public Double getSegmentElevation(int index) {
-    if (index >= 0 && index <= elevationProfile.size()) {
+    if (index >= 0 && index < elevationProfile.size()) {
       return elevationProfile.get(index);
     } else {
       throw new IndexOutOfBoundsException("Index is out of bounds.");

--- a/src/test/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrillsBoundaryTest.java
+++ b/src/test/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrillsBoundaryTest.java
@@ -1,0 +1,37 @@
+package neqsim.process.equipment.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+
+/**
+ * Tests boundary checks for PipeBeggsAndBrills profile accessors.
+ */
+public class PipeBeggsAndBrillsBoundaryTest {
+
+  @Test
+  public void testOutOfBoundsProfileIndex() {
+    neqsim.thermo.system.SystemInterface system =
+        new neqsim.thermo.system.SystemSrkEos((273.15 + 25.0), 50.0);
+    system.addComponent("methane", 1.0);
+    system.setMixingRule(2);
+    system.init(0);
+    system.setTotalFlowRate(1.0, "kg/sec");
+    system.initPhysicalProperties();
+
+    Stream stream = new Stream("stream", system);
+    PipeBeggsAndBrills pipe = new PipeBeggsAndBrills("pipe", stream);
+    pipe.setLength(100.0);
+    pipe.setDiameter(0.1);
+    pipe.setNumberOfIncrements(1);
+
+    neqsim.process.processmodel.ProcessSystem proc = new neqsim.process.processmodel.ProcessSystem();
+    proc.add(stream);
+    proc.add(pipe);
+    proc.run();
+
+    assertThrows(IndexOutOfBoundsException.class,
+        () -> pipe.getSegmentLength(pipe.getNumberOfIncrements() + 1));
+  }
+}


### PR DESCRIPTION
## Summary
- fix upper bound check in `PipeBeggsAndBrills` profile accessor methods
- add regression test covering boundary condition

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `./mvnw -q checkstyle:check` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6874929e6dc8832d9af421f55c3e8bf1