### PR TITLE
Fix equals method in Compressor

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -1772,10 +1772,10 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface 
         && Objects.equals(polytropicMethod, other.polytropicMethod) && powerSet == other.powerSet
         && Double.doubleToLongBits(pressure) == Double.doubleToLongBits(other.pressure)
         && Objects.equals(pressureUnit, other.pressureUnit) && speed == other.speed
-        && Objects.equals(thermoSystem, other.thermoSystem) && useGERG2008 == other.useGERG2008
-        && Objects.equals(thermoSystem, other.thermoSystem) && useLeachman == other.useLeachman
-        && Objects.equals(thermoSystem, other.thermoSystem) && useVega == other.useVega
-
+        && Objects.equals(thermoSystem, other.thermoSystem)
+        && useGERG2008 == other.useGERG2008
+        && useLeachman == other.useLeachman
+        && useVega == other.useVega
         && useOutTemperature == other.useOutTemperature
         && usePolytropicCalc == other.usePolytropicCalc
         && useRigorousPolytropicMethod == other.useRigorousPolytropicMethod;


### PR DESCRIPTION
## Summary
- fix repeated thermoSystem check when comparing compressors

## Testing
- `mvn -Dtest=ThermodynamicOperationsTest test`

------
https://chatgpt.com/codex/tasks/task_e_6878a0e8da28832db03d768b219ba089