### PR TITLE
Refactor HeaterResponse JSON data

### DIFF
--- a/src/main/java/neqsim/process/util/monitor/HeaterResponse.java
+++ b/src/main/java/neqsim/process/util/monitor/HeaterResponse.java
@@ -1,7 +1,8 @@
 package neqsim.process.util.monitor;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import neqsim.process.equipment.heatexchanger.Heater;
+import neqsim.process.util.monitor.Value;
 
 /**
  * <p>
@@ -12,7 +13,7 @@ import neqsim.process.equipment.heatexchanger.Heater;
  * @version $Id: $Id
  */
 public class HeaterResponse extends BaseResponse {
-  public ArrayList<String[]> data = new ArrayList<String[]>();
+  public HashMap<String, Value> data = new HashMap<String, Value>();
 
   /**
    * <p>
@@ -23,32 +24,39 @@ public class HeaterResponse extends BaseResponse {
    */
   public HeaterResponse(Heater inputHeater) {
     super(inputHeater);
+    data.put("mass flow",
+        new Value(
+            Double.toString(inputHeater.getInletStream()
+                .getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
+            neqsim.util.unit.Units.getSymbol("mass flow")));
 
-    data.add(new String[] {"mass flow",
-        Double.toString(inputHeater.getInletStream()
-            .getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
-        neqsim.util.unit.Units.getSymbol("mass flow")});
+    data.put("inlet temperature",
+        new Value(
+            Double.toString(inputHeater.getInletStream()
+                .getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
+            neqsim.util.unit.Units.getSymbol("temperature")));
 
-    data.add(new String[] {"inlet temperature",
-        Double.toString(inputHeater.getInletStream()
-            .getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
-        neqsim.util.unit.Units.getSymbol("temperature")});
+    data.put("inlet pressure",
+        new Value(
+            Double.toString(inputHeater.getInletStream()
+                .getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
+            neqsim.util.unit.Units.getSymbol("pressure")));
 
-    data.add(new String[] {"inlet pressure",
-        Double.toString(
-            inputHeater.getInletStream().getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
-        neqsim.util.unit.Units.getSymbol("pressure")});
-    data.add(new String[] {"outlet temperature",
-        Double.toString(inputHeater.getOutletStream()
-            .getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
-        neqsim.util.unit.Units.getSymbol("temperature")});
-    data.add(new String[] {"outlet pressure",
-        Double.toString(inputHeater.getOutletStream()
-            .getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
-        neqsim.util.unit.Units.getSymbol("pressure")});
+    data.put("outlet temperature",
+        new Value(
+            Double.toString(inputHeater.getOutletStream()
+                .getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
+            neqsim.util.unit.Units.getSymbol("temperature")));
 
-    data.add(new String[] {"duty",
-        Double.toString(inputHeater.getDuty(neqsim.util.unit.Units.getSymbol("duty"))),
-        neqsim.util.unit.Units.getSymbol("duty")});
+    data.put("outlet pressure",
+        new Value(
+            Double.toString(inputHeater.getOutletStream()
+                .getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
+            neqsim.util.unit.Units.getSymbol("pressure")));
+
+    data.put("duty",
+        new Value(
+            Double.toString(inputHeater.getDuty(neqsim.util.unit.Units.getSymbol("duty"))),
+            neqsim.util.unit.Units.getSymbol("duty")));
   }
 }


### PR DESCRIPTION
## Summary
- remove `StreamResponse` fields from `HeaterResponse`
- keep data in `HashMap<String, Value>` for direct JSON key access

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `./mvnw checkstyle:check` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6878b2a620f8832d9b2da9e9f2ae3c12