### PR TITLE
Refactor monitor responses to HashMap style

### DIFF
--- a/src/main/java/neqsim/process/util/monitor/ManifoldResponse.java
+++ b/src/main/java/neqsim/process/util/monitor/ManifoldResponse.java
@@ -1,13 +1,13 @@
 package neqsim.process.util.monitor;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import neqsim.process.equipment.manifold.Manifold;
 
 /**
  * ManifoldResponse class provides basic reporting for a manifold unit.
  */
 public class ManifoldResponse extends BaseResponse {
-  public ArrayList<String[]> data = new ArrayList<String[]>();
+  public HashMap<String, Value> data = new HashMap<String, Value>();
 
   /**
    * Create a response based on a {@link neqsim.process.equipment.manifold.Manifold}.
@@ -17,24 +17,28 @@ public class ManifoldResponse extends BaseResponse {
   public ManifoldResponse(Manifold manifold) {
     super(manifold);
 
-    data.add(new String[] {"mixed mass flow",
-        Double.toString(manifold.getMixedStream()
-            .getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
-        neqsim.util.unit.Units.getSymbol("mass flow")});
-    data.add(new String[] {"mixed temperature",
-        Double.toString(manifold.getMixedStream()
-            .getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
-        neqsim.util.unit.Units.getSymbol("temperature")});
-    data.add(new String[] {"mixed pressure",
-        Double.toString(manifold.getMixedStream()
-            .getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
-        neqsim.util.unit.Units.getSymbol("pressure")});
+    data.put("mixed mass flow",
+        new Value(
+            Double.toString(manifold.getMixedStream()
+                .getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
+            neqsim.util.unit.Units.getSymbol("mass flow")));
+    data.put("mixed temperature",
+        new Value(
+            Double.toString(manifold.getMixedStream()
+                .getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
+            neqsim.util.unit.Units.getSymbol("temperature")));
+    data.put("mixed pressure",
+        new Value(
+            Double.toString(manifold.getMixedStream()
+                .getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
+            neqsim.util.unit.Units.getSymbol("pressure")));
 
     for (int i = 0; i < manifold.getNumberOfOutputStreams(); i++) {
-      data.add(new String[] {"split mass flow " + (i + 1),
-          Double.toString(manifold.getSplitStream(i)
-              .getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
-          neqsim.util.unit.Units.getSymbol("mass flow")});
+      data.put("split mass flow " + (i + 1),
+          new Value(
+              Double.toString(manifold.getSplitStream(i)
+                  .getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
+              neqsim.util.unit.Units.getSymbol("mass flow")));
     }
   }
 }

--- a/src/main/java/neqsim/process/util/monitor/MixerResponse.java
+++ b/src/main/java/neqsim/process/util/monitor/MixerResponse.java
@@ -1,13 +1,13 @@
 package neqsim.process.util.monitor;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import neqsim.process.equipment.mixer.Mixer;
 
 /**
  * MixerResponse class provides basic reporting for a mixer unit.
  */
 public class MixerResponse extends BaseResponse {
-  public ArrayList<String[]> data = new ArrayList<String[]>();
+  public HashMap<String, Value> data = new HashMap<String, Value>();
 
   /**
    * Create a response based on a {@link neqsim.process.equipment.mixer.Mixer}.
@@ -17,17 +17,20 @@ public class MixerResponse extends BaseResponse {
   public MixerResponse(Mixer mixer) {
     super(mixer);
 
-    data.add(new String[] {"mass flow",
-        Double.toString(mixer.getOutletStream()
-            .getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
-        neqsim.util.unit.Units.getSymbol("mass flow")});
-    data.add(new String[] {"outlet temperature",
-        Double.toString(mixer.getOutletStream()
-            .getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
-        neqsim.util.unit.Units.getSymbol("temperature")});
-    data.add(new String[] {"outlet pressure",
-        Double.toString(
-            mixer.getOutletStream().getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
-        neqsim.util.unit.Units.getSymbol("pressure")});
+    data.put("mass flow",
+        new Value(
+            Double.toString(mixer.getOutletStream()
+                .getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
+            neqsim.util.unit.Units.getSymbol("mass flow")));
+    data.put("outlet temperature",
+        new Value(
+            Double.toString(mixer.getOutletStream()
+                .getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
+            neqsim.util.unit.Units.getSymbol("temperature")));
+    data.put("outlet pressure",
+        new Value(
+            Double.toString(
+                mixer.getOutletStream().getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
+            neqsim.util.unit.Units.getSymbol("pressure")));
   }
 }

--- a/src/main/java/neqsim/process/util/monitor/MultiStreamHeatExchanger2Response.java
+++ b/src/main/java/neqsim/process/util/monitor/MultiStreamHeatExchanger2Response.java
@@ -1,6 +1,6 @@
 package neqsim.process.util.monitor;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import neqsim.process.equipment.heatexchanger.MultiStreamHeatExchanger2;
 
 /**
@@ -12,7 +12,7 @@ import neqsim.process.equipment.heatexchanger.MultiStreamHeatExchanger2;
  * @version $Id: $Id
  */
 public class MultiStreamHeatExchanger2Response extends BaseResponse {
-  public ArrayList<String[]> data = new ArrayList<String[]>();
+  public HashMap<String, Value> data = new HashMap<String, Value>();
   public Double temperatureApproach;
 
   public java.util.Map<String, java.util.List<java.util.Map<String, Object>>> compositeCurveResults;
@@ -36,7 +36,8 @@ public class MultiStreamHeatExchanger2Response extends BaseResponse {
     super(inputHeatExchanger);
     temperatureApproach = inputHeatExchanger.getTemperatureApproach();
     compositeCurveResults = inputHeatExchanger.getCompositeCurve();
-    data.add(new String[] {"temperature approach", Double.toString(temperatureApproach),
-        neqsim.util.unit.Units.getSymbol("temperature")});
+    data.put("temperature approach",
+        new Value(Double.toString(temperatureApproach),
+            neqsim.util.unit.Units.getSymbol("temperature")));
   }
 }

--- a/src/main/java/neqsim/process/util/monitor/MultiStreamHeatExchangerResponse.java
+++ b/src/main/java/neqsim/process/util/monitor/MultiStreamHeatExchangerResponse.java
@@ -1,6 +1,6 @@
 package neqsim.process.util.monitor;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import neqsim.process.equipment.heatexchanger.MultiStreamHeatExchanger;
 
 /**
@@ -12,7 +12,7 @@ import neqsim.process.equipment.heatexchanger.MultiStreamHeatExchanger;
  * @version $Id: $Id
  */
 public class MultiStreamHeatExchangerResponse extends BaseResponse {
-  public ArrayList<String[]> data = new ArrayList<String[]>();
+  public HashMap<String, Value> data = new HashMap<String, Value>();
   public Double[] feedTemperature;
   public Double[] dischargeTemperature;
   public Double[] duty;
@@ -42,16 +42,20 @@ public class MultiStreamHeatExchangerResponse extends BaseResponse {
       flowRate[i] = inputHX.getInStream(i).getFlowRate("kg/hr");
 
       String streamId = Integer.toString(i + 1);
-      data.add(new String[] {"feed temperature stream " + streamId,
-          Double.toString(feedTemperature[i]), neqsim.util.unit.Units.getSymbol("temperature")});
-      data.add(new String[] {"discharge temperature stream " + streamId,
-          Double.toString(dischargeTemperature[i]), neqsim.util.unit.Units.getSymbol("temperature")});
-      data.add(new String[] {"duty stream " + streamId, Double.toString(duty[i]),
-          neqsim.util.unit.Units.getSymbol("duty")});
-      data.add(new String[] {"mass flow stream " + streamId, Double.toString(flowRate[i]),
-          neqsim.util.unit.Units.getSymbol("mass flow")});
+      data.put("feed temperature stream " + streamId,
+          new Value(Double.toString(feedTemperature[i]),
+              neqsim.util.unit.Units.getSymbol("temperature")));
+      data.put("discharge temperature stream " + streamId,
+          new Value(Double.toString(dischargeTemperature[i]),
+              neqsim.util.unit.Units.getSymbol("temperature")));
+      data.put("duty stream " + streamId,
+          new Value(Double.toString(duty[i]),
+              neqsim.util.unit.Units.getSymbol("duty")));
+      data.put("mass flow stream " + streamId,
+          new Value(Double.toString(flowRate[i]),
+              neqsim.util.unit.Units.getSymbol("mass flow")));
     }
 
-    data.add(new String[] {"UA value", Double.toString(inputHX.getUAvalue()), "W/K"});
+    data.put("UA value", new Value(Double.toString(inputHX.getUAvalue()), "W/K"));
   }
 }

--- a/src/main/java/neqsim/process/util/monitor/PumpResponse.java
+++ b/src/main/java/neqsim/process/util/monitor/PumpResponse.java
@@ -1,6 +1,6 @@
 package neqsim.process.util.monitor;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import neqsim.process.equipment.pump.Pump;
 
 /**
@@ -12,7 +12,7 @@ import neqsim.process.equipment.pump.Pump;
  * @version $Id: $Id
  */
 public class PumpResponse extends BaseResponse {
-  public ArrayList<String[]> data = new ArrayList<String[]>();
+  public HashMap<String, Value> data = new HashMap<String, Value>();
   public Double suctionTemperature;
   public Double dischargeTemperature;
   public Double suctionPressure;
@@ -60,17 +60,22 @@ public class PumpResponse extends BaseResponse {
     // inputCompressor.getCompressorChart().getSurgeCurve().getSurgeFlow(polytropicHead);
     // }
 
-    data.add(new String[] {"suction temperature", Double.toString(suctionTemperature),
-        neqsim.util.unit.Units.getSymbol("temperature")});
-    data.add(new String[] {"discharge temperature", Double.toString(dischargeTemperature),
-        neqsim.util.unit.Units.getSymbol("temperature")});
-    data.add(new String[] {"suction pressure", Double.toString(suctionPressure),
-        neqsim.util.unit.Units.getSymbol("pressure")});
-    data.add(new String[] {"discharge pressure", Double.toString(dischargePressure),
-        neqsim.util.unit.Units.getSymbol("pressure")});
-    data.add(new String[] {"mass flow", Double.toString(massflow),
-        neqsim.util.unit.Units.getSymbol("mass flow")});
-    data.add(new String[] {"duty", Double.toString(duty), neqsim.util.unit.Units.getSymbol("duty")});
-    data.add(new String[] {"power", Double.toString(power), "W"});
+    data.put("suction temperature",
+        new Value(Double.toString(suctionTemperature),
+            neqsim.util.unit.Units.getSymbol("temperature")));
+    data.put("discharge temperature",
+        new Value(Double.toString(dischargeTemperature),
+            neqsim.util.unit.Units.getSymbol("temperature")));
+    data.put("suction pressure",
+        new Value(Double.toString(suctionPressure),
+            neqsim.util.unit.Units.getSymbol("pressure")));
+    data.put("discharge pressure",
+        new Value(Double.toString(dischargePressure),
+            neqsim.util.unit.Units.getSymbol("pressure")));
+    data.put("mass flow",
+        new Value(Double.toString(massflow), neqsim.util.unit.Units.getSymbol("mass flow")));
+    data.put("duty",
+        new Value(Double.toString(duty), neqsim.util.unit.Units.getSymbol("duty")));
+    data.put("power", new Value(Double.toString(power), "W"));
   }
 }

--- a/src/main/java/neqsim/process/util/monitor/RecycleResponse.java
+++ b/src/main/java/neqsim/process/util/monitor/RecycleResponse.java
@@ -1,13 +1,13 @@
 package neqsim.process.util.monitor;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import neqsim.process.equipment.util.Recycle;
 
 /**
  * RecycleResponse class provides basic reporting for a recycle unit.
  */
 public class RecycleResponse extends BaseResponse {
-  public ArrayList<String[]> data = new ArrayList<String[]>();
+  public HashMap<String, Value> data = new HashMap<String, Value>();
 
   /**
    * Create a response based on a {@link neqsim.process.equipment.util.Recycle}.
@@ -17,22 +17,28 @@ public class RecycleResponse extends BaseResponse {
   public RecycleResponse(Recycle recycle) {
     super(recycle);
 
-    data.add(new String[] {"outlet mass flow",
-        Double.toString(recycle.getOutletStream()
-            .getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
-        neqsim.util.unit.Units.getSymbol("mass flow")});
-    data.add(new String[] {"outlet temperature",
-        Double.toString(recycle.getOutletStream()
-            .getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
-        neqsim.util.unit.Units.getSymbol("temperature")});
-    data.add(new String[] {"outlet pressure",
-        Double.toString(recycle.getOutletStream()
-            .getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
-        neqsim.util.unit.Units.getSymbol("pressure")});
+    data.put("outlet mass flow",
+        new Value(
+            Double.toString(recycle.getOutletStream()
+                .getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
+            neqsim.util.unit.Units.getSymbol("mass flow")));
+    data.put("outlet temperature",
+        new Value(
+            Double.toString(recycle.getOutletStream()
+                .getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
+            neqsim.util.unit.Units.getSymbol("temperature")));
+    data.put("outlet pressure",
+        new Value(
+            Double.toString(recycle.getOutletStream()
+                .getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
+            neqsim.util.unit.Units.getSymbol("pressure")));
 
-    data.add(new String[] {"error composition", Double.toString(recycle.getErrorComposition()), ""});
-    data.add(new String[] {"error flow", Double.toString(recycle.getErrorFlow()), ""});
-    data.add(new String[] {"error temperature", Double.toString(recycle.getErrorTemperature()), ""});
-    data.add(new String[] {"error pressure", Double.toString(recycle.getErrorPressure()), ""});
+    data.put("error composition",
+        new Value(Double.toString(recycle.getErrorComposition()), ""));
+    data.put("error flow", new Value(Double.toString(recycle.getErrorFlow()), ""));
+    data.put("error temperature",
+        new Value(Double.toString(recycle.getErrorTemperature()), ""));
+    data.put("error pressure",
+        new Value(Double.toString(recycle.getErrorPressure()), ""));
   }
 }

--- a/src/main/java/neqsim/process/util/monitor/TankResponse.java
+++ b/src/main/java/neqsim/process/util/monitor/TankResponse.java
@@ -1,6 +1,6 @@
 package neqsim.process.util.monitor;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import neqsim.process.equipment.tank.Tank;
 
 /**
@@ -10,7 +10,7 @@ import neqsim.process.equipment.tank.Tank;
  * </p>
  */
 public class TankResponse extends BaseResponse {
-  public ArrayList<String[]> data = new ArrayList<String[]>();
+  public HashMap<String, Value> data = new HashMap<String, Value>();
 
   /**
    * Create a response based on a {@link neqsim.process.equipment.tank.Tank}.
@@ -20,27 +20,39 @@ public class TankResponse extends BaseResponse {
   public TankResponse(Tank tank) {
     super(tank);
 
-    data.add(new String[] {"liquid level", Double.toString(tank.getLiquidLevel()), ""});
-    data.add(new String[] {"volume", Double.toString(tank.getVolume()), "m3"});
+    data.put("liquid level", new Value(Double.toString(tank.getLiquidLevel()), ""));
+    data.put("volume", new Value(Double.toString(tank.getVolume()), "m3"));
 
-    data.add(new String[] {"gas outlet temperature",
-        Double.toString(tank.getGasOutStream().getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
-        neqsim.util.unit.Units.getSymbol("temperature")});
-    data.add(new String[] {"gas outlet pressure",
-        Double.toString(tank.getGasOutStream().getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
-        neqsim.util.unit.Units.getSymbol("pressure")});
-    data.add(new String[] {"gas outlet mass flow",
-        Double.toString(tank.getGasOutStream().getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
-        neqsim.util.unit.Units.getSymbol("mass flow")});
+    data.put("gas outlet temperature",
+        new Value(
+            Double.toString(tank.getGasOutStream()
+                .getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
+            neqsim.util.unit.Units.getSymbol("temperature")));
+    data.put("gas outlet pressure",
+        new Value(
+            Double.toString(tank.getGasOutStream()
+                .getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
+            neqsim.util.unit.Units.getSymbol("pressure")));
+    data.put("gas outlet mass flow",
+        new Value(
+            Double.toString(tank.getGasOutStream()
+                .getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
+            neqsim.util.unit.Units.getSymbol("mass flow")));
 
-    data.add(new String[] {"liquid outlet temperature",
-        Double.toString(tank.getLiquidOutStream().getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
-        neqsim.util.unit.Units.getSymbol("temperature")});
-    data.add(new String[] {"liquid outlet pressure",
-        Double.toString(tank.getLiquidOutStream().getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
-        neqsim.util.unit.Units.getSymbol("pressure")});
-    data.add(new String[] {"liquid outlet mass flow",
-        Double.toString(tank.getLiquidOutStream().getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
-        neqsim.util.unit.Units.getSymbol("mass flow")});
+    data.put("liquid outlet temperature",
+        new Value(
+            Double.toString(tank.getLiquidOutStream()
+                .getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
+            neqsim.util.unit.Units.getSymbol("temperature")));
+    data.put("liquid outlet pressure",
+        new Value(
+            Double.toString(tank.getLiquidOutStream()
+                .getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
+            neqsim.util.unit.Units.getSymbol("pressure")));
+    data.put("liquid outlet mass flow",
+        new Value(
+            Double.toString(tank.getLiquidOutStream()
+                .getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
+            neqsim.util.unit.Units.getSymbol("mass flow")));
   }
 }

--- a/src/main/java/neqsim/process/util/monitor/ValveResponse.java
+++ b/src/main/java/neqsim/process/util/monitor/ValveResponse.java
@@ -1,6 +1,6 @@
 package neqsim.process.util.monitor;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import neqsim.process.equipment.valve.ValveInterface;
 
 /**
@@ -12,7 +12,7 @@ import neqsim.process.equipment.valve.ValveInterface;
  * @version $Id: $Id
  */
 public class ValveResponse extends BaseResponse {
-  public ArrayList<String[]> data = new ArrayList<String[]>();
+  public HashMap<String, Value> data = new HashMap<String, Value>();
 
   /**
    * <p>
@@ -23,26 +23,31 @@ public class ValveResponse extends BaseResponse {
    */
   public ValveResponse(ValveInterface valve) {
     super(valve);
-    data.add(new String[] {"mass flow",
-        Double.toString(
-            valve.getInletStream().getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
-        neqsim.util.unit.Units.getSymbol("mass flow")});
-    data.add(new String[] {"inlet temperature",
-        Double.toString(
-            valve.getInletStream().getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
-        neqsim.util.unit.Units.getSymbol("temperature")});
-    data.add(new String[] {"inlet pressure",
-        Double.toString(
-            valve.getInletStream().getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
-        neqsim.util.unit.Units.getSymbol("pressure")});
-    data.add(new String[] {"outlet temperature",
-        Double.toString(valve.getOutletStream()
-            .getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
-        neqsim.util.unit.Units.getSymbol("temperature")});
-    data.add(new String[] {"outlet pressure",
-        Double.toString(
-            valve.getOutletStream().getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
-        neqsim.util.unit.Units.getSymbol("pressure")});
+    data.put("mass flow",
+        new Value(
+            Double.toString(
+                valve.getInletStream().getFlowRate(neqsim.util.unit.Units.getSymbol("mass flow"))),
+            neqsim.util.unit.Units.getSymbol("mass flow")));
+    data.put("inlet temperature",
+        new Value(
+            Double.toString(
+                valve.getInletStream().getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
+            neqsim.util.unit.Units.getSymbol("temperature")));
+    data.put("inlet pressure",
+        new Value(
+            Double.toString(
+                valve.getInletStream().getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
+            neqsim.util.unit.Units.getSymbol("pressure")));
+    data.put("outlet temperature",
+        new Value(
+            Double.toString(valve.getOutletStream()
+                .getTemperature(neqsim.util.unit.Units.getSymbol("temperature"))),
+            neqsim.util.unit.Units.getSymbol("temperature")));
+    data.put("outlet pressure",
+        new Value(
+            Double.toString(
+                valve.getOutletStream().getPressure(neqsim.util.unit.Units.getSymbol("pressure"))),
+            neqsim.util.unit.Units.getSymbol("pressure")));
   }
 
   /**

--- a/src/main/java/neqsim/process/util/monitor/WellAllocatorResponse.java
+++ b/src/main/java/neqsim/process/util/monitor/WellAllocatorResponse.java
@@ -1,5 +1,6 @@
 package neqsim.process.util.monitor;
 
+import java.util.HashMap;
 import neqsim.process.measurementdevice.WellAllocator;
 
 /**
@@ -12,7 +13,7 @@ import neqsim.process.measurementdevice.WellAllocator;
  */
 public class WellAllocatorResponse {
   public String name;
-  public Double gasExportRate, oilExportRate, totalExportRate;
+  public HashMap<String, Value> data = new HashMap<String, Value>();
 
   /**
    * <p>
@@ -23,8 +24,17 @@ public class WellAllocatorResponse {
    */
   public WellAllocatorResponse(WellAllocator inputAllocator) {
     name = inputAllocator.getName();
-    gasExportRate = inputAllocator.getMeasuredValue("gas export rate", "kg/hr");
-    oilExportRate = inputAllocator.getMeasuredValue("oil export rate", "kg/hr");
-    totalExportRate = inputAllocator.getMeasuredValue("total export rate", "kg/hr");
+    data.put("gas export rate",
+        new Value(
+            Double.toString(inputAllocator.getMeasuredValue("gas export rate", "kg/hr")),
+            "kg/hr"));
+    data.put("oil export rate",
+        new Value(
+            Double.toString(inputAllocator.getMeasuredValue("oil export rate", "kg/hr")),
+            "kg/hr"));
+    data.put("total export rate",
+        new Value(
+            Double.toString(inputAllocator.getMeasuredValue("total export rate", "kg/hr")),
+            "kg/hr"));
   }
 }

--- a/src/test/java/neqsim/process/measurementdevice/WellAllocatorTest.java
+++ b/src/test/java/neqsim/process/measurementdevice/WellAllocatorTest.java
@@ -74,9 +74,12 @@ class WellAllocatorTest extends neqsim.NeqSimTest {
     WellAllocatorResponse responsAl = new WellAllocatorResponse(wellAlloc);
 
     logger.info("name " + responsAl.name);
-    logger.info("gas flow " + responsAl.gasExportRate);
-    logger.info("oil flow " + responsAl.oilExportRate);
-    logger.info("total flow " + responsAl.totalExportRate);
+    logger.info("gas flow "
+        + responsAl.data.get("gas export rate").value);
+    logger.info("oil flow "
+        + responsAl.data.get("oil export rate").value);
+    logger.info("total flow "
+        + responsAl.data.get("total export rate").value);
     // stream_1.displayResult();
     // stream_1.displayResult();
   }


### PR DESCRIPTION
## Summary
- standardize monitor response classes to use `HashMap<String, Value>`
- update WellAllocator test for new response format

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `./mvnw -q checkstyle:check` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6879edc673ec832db656258db52e2485