### PR TITLE
Fix typo in component error message

### DIFF
--- a/src/main/java/neqsim/thermo/component/Component.java
+++ b/src/main/java/neqsim/thermo/component/Component.java
@@ -515,7 +515,7 @@ public abstract class Component implements ComponentInterface {
       } else {
         String msg = "will lead to negative number of moles of component in phase for component "
             + getComponentName() + "  who has " + numberOfMolesInPhase
-            + " in phase  and chage request was " + dn;
+            + " in phase  and change request was " + dn;
         logger.error(msg);
         if (numberOfMolesInPhase + dn < 0) {
           dn = -numberOfMolesInPhase;


### PR DESCRIPTION
## Summary
- fix spelling mistake in error message referring to change requests

## Testing
- `mvn -Dtest=ThermodynamicOperationsTest test -X`
- `mvn checkstyle:check`

------
https://chatgpt.com/codex/tasks/task_e_6879edfaa2e0832d8e43b7b175e5b03a