### PR TITLE
Ensure temperature unit conversions reject unsupported inputs

### DIFF
--- a/src/main/java/neqsim/util/unit/TemperatureUnit.java
+++ b/src/main/java/neqsim/util/unit/TemperatureUnit.java
@@ -53,14 +53,23 @@ public class TemperatureUnit extends neqsim.util.unit.BaseUnit {
       return value;
     }
 
-    // Convert input to Kelvin first
-    double tempInKelvin = value;
-    if (fromUnit.equals("C")) {
-      tempInKelvin += 273.15;
-    } else if (fromUnit.equals("F")) {
-      tempInKelvin = (value - 32) * 5.0 / 9.0 + 273.15;
-    } else if (fromUnit.equals("R")) {
-      tempInKelvin = value * 5.0 / 9.0;
+    // Convert input to Kelvin first. Unknown units should not default to Kelvin.
+    double tempInKelvin;
+    switch (fromUnit) {
+      case "K":
+        tempInKelvin = value;
+        break;
+      case "C":
+        tempInKelvin = value + 273.15;
+        break;
+      case "F":
+        tempInKelvin = (value - 32) * 5.0 / 9.0 + 273.15;
+        break;
+      case "R":
+        tempInKelvin = value * 5.0 / 9.0;
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported unit: " + fromUnit);
     }
 
     // Convert from Kelvin to target unit

--- a/src/test/java/neqsim/util/unit/TemperatureUnitTest.java
+++ b/src/test/java/neqsim/util/unit/TemperatureUnitTest.java
@@ -1,6 +1,7 @@
 package neqsim.util.unit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
 import neqsim.thermo.ThermodynamicConstantsInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -48,6 +49,16 @@ class TemperatureUnitTest extends neqsim.NeqSimTest {
     assertEquals(77.4499999999, fluid.getTemperature("F"), 1e-4);
     assertEquals(537.12, fluid.getTemperature("R"), 1e-4);
     assertEquals(298.4, fluid.getTemperature("K"), 1e-4);
+  }
+
+  /**
+   * Verify that requesting conversions with unsupported units throws an exception.
+   */
+  @Test
+  public void testUnsupportedUnit() {
+    TemperatureUnit unit = new TemperatureUnit(0.0, "test");
+    assertThrows(IllegalArgumentException.class, () -> unit.getValue(0.0, "X", "K"));
+    assertThrows(IllegalArgumentException.class, () -> unit.getValue(0.0, "K", "X"));
   }
 }
 


### PR DESCRIPTION
## Summary
- prevent `TemperatureUnit.getValue` from silently treating unknown source units as Kelvin by validating the `fromUnit` value
- add tests confirming unsupported units trigger an `IllegalArgumentException`

## Testing
- `mvn -Dtest=TemperatureUnitTest test`


------
https://chatgpt.com/codex/tasks/task_e_6892f3985f1c832da5e6fb5e02950e6a