### PR TITLE
Fix gas valve detection based on phase presence

### DIFF
--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -222,7 +222,7 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface 
     }
     thermoSystem.initProperties();
 
-    if (thermoSystem.hasPhaseType(PhaseType.GAS) && thermoSystem.getVolumeFraction(0) > 0.5) {
+    if (thermoSystem.hasPhaseType(PhaseType.GAS)) {
       setGasValve(true);
     } else {
       setGasValve(false);


### PR DESCRIPTION
## Summary
- only check for gas phase presence when determining if a valve handles gas

## Testing
- `mvn -Dtest=ThrottlingValveTest test`


------
https://chatgpt.com/codex/tasks/task_e_6892f36e87e4832dbb375c41386bc5ae