### PR TITLE
Add stone wall curve generation

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/CompressorChartInterface.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorChartInterface.java
@@ -211,6 +211,7 @@ public interface CompressorChartInterface extends Cloneable {
    */
   public double getMinSpeedCurve();
 
-
   public void generateSurgeCurve();
+
+  public void generateStoneWallCurve();
 }

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorChartKhader2015.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorChartKhader2015.java
@@ -420,6 +420,7 @@ public class CompressorChartKhader2015 extends CompressorChartAlternativeMapLook
     setSurgeCurve(new SafeSplineSurgeCurve(surgeFlow, surgeHead));
   }
 
+
   /**
    * Simple POJO to hold corrected (dimensionless) compressor curve data for a given speed.
    */

--- a/src/main/java/neqsim/process/mechanicaldesign/valve/ControlValveSizing.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/valve/ControlValveSizing.java
@@ -19,6 +19,8 @@ public class ControlValveSizing implements ControlValveSizingInterface, Serializ
   }
 
   private static final double KV_TO_CV_FACTOR = 1.156;
+  private static final double SECONDS_PER_HOUR = 3600.0;
+  private static final int MAX_BISECTION_ITERATIONS = 100;
   double xT = 0.137;
   boolean allowChoked = true;
 

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorChartKhader2015Test.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorChartKhader2015Test.java
@@ -134,9 +134,26 @@ public class CompressorChartKhader2015Test {
 
     comp1.getCompressorChart().generateSurgeCurve();
     comp1.getSurgeFlowRate();
-    // Assertions.assertEquals(161.038905, comp1.getSurgeFlowRate(), 1.0);
-    // compChart.prettyPrintChartValues();
-    // compChart.prettyPrintRealCurvesForFluid();
+    CompressorChartKhader2015 testChart = new CompressorChartKhader2015(stream_1.getFluid(), 0.9);
+    testChart.setCurves(chartConditions, speed, flow, head, flow, polyEff);
+    testChart.generateStoneWallCurve();
+    StoneWallCurve sw = testChart.getStoneWallCurve();
+    double cs = testChart.getReferenceFluid().getPhase(0).getSoundSpeed();
+    double D = testChart.getImpellerOuterDiameter();
+    double[][] pairs = new double[speed.length][2];
+    for (int i = 0; i < speed.length; i++) {
+      pairs[i][0] = flow[i][flow[i].length - 1] / 3600.0 / cs / D / D;
+      pairs[i][1] = head[i][head[i].length - 1] / cs / cs;
+    }
+    java.util.Arrays.sort(pairs, java.util.Comparator.comparingDouble(a -> a[0]));
+    double[] expectedFlow = new double[speed.length];
+    double[] expectedHead = new double[speed.length];
+    for (int i = 0; i < speed.length; i++) {
+      expectedFlow[i] = pairs[i][0];
+      expectedHead[i] = pairs[i][1];
+    }
+    Assertions.assertArrayEquals(expectedFlow, sw.flow, 1e-12);
+    Assertions.assertArrayEquals(expectedHead, sw.head, 1e-12);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- generate stone wall curve from compressor chart by pairing highest flow per speed with head values
- expose stone wall curve generation in the base chart and interface for reuse
- add regression test for stone wall curve calculations
- define missing constants in ControlValveSizing

## Testing
- `mvn -e -Dtest=CompressorChartKhader2015Test test`


------
https://chatgpt.com/codex/tasks/task_e_689315655158832d9c2ffb49c5cbeb5f