### PR TITLE
refactor: add shared boundary curve base for surge and stonewall

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/BoundaryCurve.java
+++ b/src/main/java/neqsim/process/equipment/compressor/BoundaryCurve.java
@@ -1,0 +1,96 @@
+package neqsim.process.equipment.compressor;
+
+import java.util.Arrays;
+import java.util.Objects;
+import org.apache.commons.math3.analysis.polynomials.PolynomialFunction;
+import org.apache.commons.math3.fitting.PolynomialCurveFitter;
+import org.apache.commons.math3.fitting.WeightedObservedPoints;
+
+/**
+ * Abstract base implementation for compressor limit curves such as surge and stone wall curves.
+ */
+public abstract class BoundaryCurve implements BoundaryCurveInterface {
+  private static final long serialVersionUID = 1000L;
+
+  protected double[] flow;
+  protected double[] head;
+  protected double[] chartConditions;
+  protected boolean isActive = false;
+
+  protected WeightedObservedPoints flowFitter = new WeightedObservedPoints();
+  protected PolynomialFunction flowFitterFunc = null;
+
+  protected BoundaryCurve() {}
+
+  protected BoundaryCurve(double[] flow, double[] head) {
+    setCurve(null, flow, head);
+  }
+
+  @Override
+  public void setCurve(double[] chartConditions, double[] flow, double[] head) {
+    this.flow = flow;
+    this.head = head;
+    this.chartConditions = chartConditions;
+    flowFitter = new WeightedObservedPoints();
+    for (int i = 0; i < flow.length; i++) {
+      flowFitter.add(head[i], flow[i]);
+    }
+    PolynomialCurveFitter fitter = PolynomialCurveFitter.create(2);
+    flowFitterFunc = new PolynomialFunction(fitter.fit(flowFitter.toList()));
+    isActive = true;
+  }
+
+  @Override
+  public double getFlow(double head) {
+    return flowFitterFunc.value(head);
+  }
+
+  @Override
+  public boolean isActive() {
+    return isActive;
+  }
+
+  @Override
+  public void setActive(boolean isActive) {
+    this.isActive = isActive;
+  }
+
+  /** Get flow values defining the curve. */
+  public double[] getFlow() {
+    return flow;
+  }
+
+  /** Get head values defining the curve. */
+  public double[] getHead() {
+    return head;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + Arrays.hashCode(chartConditions);
+    result = prime * result + Arrays.hashCode(flow);
+    result = prime * result + Arrays.hashCode(head);
+    result = prime * result + Objects.hash(flowFitterFunc, isActive);
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    BoundaryCurve other = (BoundaryCurve) obj;
+    return Arrays.equals(chartConditions, other.chartConditions) && Arrays.equals(flow, other.flow)
+        && Arrays.equals(head, other.head) && Objects.equals(flowFitterFunc, other.flowFitterFunc)
+        && isActive == other.isActive;
+  }
+}
+

--- a/src/main/java/neqsim/process/equipment/compressor/BoundaryCurveInterface.java
+++ b/src/main/java/neqsim/process/equipment/compressor/BoundaryCurveInterface.java
@@ -1,0 +1,47 @@
+package neqsim.process.equipment.compressor;
+
+/**
+ * Common interface for compressor limit curves such as surge and stone wall curves.
+ */
+public interface BoundaryCurveInterface extends java.io.Serializable {
+  /**
+   * Define the curve from arrays of flow and head values with optional chart conditions.
+   *
+   * @param chartConditions conditions for the reference curve, or null
+   * @param flow array of flow values
+   * @param head array of head values
+   */
+  void setCurve(double[] chartConditions, double[] flow, double[] head);
+
+  /**
+   * Get the flow corresponding to a given head value on the curve.
+   *
+   * @param head the head value
+   * @return the corresponding flow
+   */
+  double getFlow(double head);
+
+  /**
+   * Check if a flow/head point is on the limiting side of the curve.
+   *
+   * @param head the head value
+   * @param flow the flow value
+   * @return true if the point violates the limit represented by the curve
+   */
+  boolean isLimit(double head, double flow);
+
+  /**
+   * Determine if the curve is active in calculations.
+   *
+   * @return true if the curve is active
+   */
+  boolean isActive();
+
+  /**
+   * Activate or deactivate the curve.
+   *
+   * @param isActive true to activate the curve
+   */
+  void setActive(boolean isActive);
+}
+

--- a/src/main/java/neqsim/process/equipment/compressor/StoneWallCurve.java
+++ b/src/main/java/neqsim/process/equipment/compressor/StoneWallCurve.java
@@ -1,160 +1,55 @@
 package neqsim.process.equipment.compressor;
 
-import java.util.Arrays;
-import java.util.Objects;
-import org.apache.commons.math3.analysis.polynomials.PolynomialFunction;
-import org.apache.commons.math3.fitting.PolynomialCurveFitter;
-import org.apache.commons.math3.fitting.WeightedObservedPoints;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * <p>
- * StoneWallCurve class.
- * </p>
- *
- * @author asmund
- * @version $Id: $Id
+ * StoneWallCurve defines the compressor stone wall (choke) limit.
  */
-public class StoneWallCurve implements java.io.Serializable {
-  /** Serialization version UID. */
-  private static final long serialVersionUID = 1000;
+public class StoneWallCurve extends BoundaryCurve {
+  private static final long serialVersionUID = 1000L;
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(StoneWallCurve.class);
 
-  double[] flow;
-  double[] head;
-  double[] chartConditions = null;
-  private boolean isActive = false;
-  final WeightedObservedPoints flowFitter = new WeightedObservedPoints();
-  PolynomialFunction flowFitterFunc = null;
-
-  /**
-   * <p>
-   * Constructor for StoneWallCurve.
-   * </p>
-   */
+  /** Default constructor. */
   public StoneWallCurve() {
-    // flow = new double[] {453.2, 600.0, 750.0};
-    // head = new double[] {1000.0, 900.0, 800.0};
+    super();
   }
 
   /**
-   * <p>
-   * Constructor for StoneWallCurve.
-   * </p>
+   * Create a stone wall curve from flow and head arrays.
    *
-   * @param flow an array of type double
-   * @param head an array of type double
+   * @param flow array of flow values
+   * @param head array of head values
    */
   public StoneWallCurve(double[] flow, double[] head) {
-    this.flow = flow;
-    this.head = head;
-  }
-
-  public double[] getFlow() {
-    return flow;
-  }
-
-  public double[] getHead() {
-    return head;
+    super(flow, head);
   }
 
   /**
-   * <p>
-   * setCurve.
-   * </p>
+   * Get the stone wall flow for a given head.
    *
-   * @param chartConditions an array of type double
-   * @param flow an array of type double
-   * @param head an array of type double
-   */
-  public void setCurve(double[] chartConditions, double[] flow, double[] head) {
-    this.chartConditions = chartConditions;
-    for (int i = 0; i < flow.length; i++) {
-      flowFitter.add(head[i], flow[i]);
-    }
-    PolynomialCurveFitter fitter = PolynomialCurveFitter.create(2);
-    flowFitterFunc = new PolynomialFunction(fitter.fit(flowFitter.toList()));
-    isActive = true;
-  }
-
-  /**
-   * <p>
-   * getStoneWallFlow.
-   * </p>
-   *
-   * @param head a double
-   * @return a double
+   * @param head head value
+   * @return stone wall flow
    */
   public double getStoneWallFlow(double head) {
-    return flowFitterFunc.value(head);
+    return getFlow(head);
   }
 
   /**
-   * <p>
-   * isStoneWall.
-   * </p>
+   * Check if the given point is beyond the stone wall limit.
    *
-   * @param head a double
-   * @param flow a double
-   * @return a boolean
+   * @param head head value
+   * @param flow flow value
+   * @return true if the point is beyond the stone wall limit
    */
   public boolean isStoneWall(double head, double flow) {
-    if (getStoneWallFlow(head) < flow) {
-      return true;
-    } else {
-      return false;
-    }
+    return isLimit(head, flow);
   }
 
-  /**
-   * Getter for property isActive.
-   *
-   * @return boolean
-   */
-  boolean isActive() {
-    return isActive;
-  }
-
-  /**
-   * Setter for property isActive.
-   *
-   * @param isActive true if stone wall curve should be used for compressor calculations
-   */
-  void setActive(boolean isActive) {
-    this.isActive = isActive;
-  }
-
-  /** {@inheritDoc} */
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + Arrays.hashCode(chartConditions);
-    result = prime * result + Arrays.hashCode(flow);
-    result = prime * result + Arrays.hashCode(head);
-    result = prime * result + Objects.hash(flowFitterFunc, isActive);
-    // result = prime * result + Objects.hash(flowFitter);
-    return result;
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    StoneWallCurve other = (StoneWallCurve) obj;
-    return Arrays.equals(chartConditions, other.chartConditions) && Arrays.equals(flow, other.flow)
-        && Objects.equals(flowFitterFunc, other.flowFitterFunc) && Arrays.equals(head, other.head)
-        && isActive == other.isActive;
-    // && Objects.equals(flowFitter, other.flowFitter)
+  public boolean isLimit(double head, double flow) {
+    return getFlow(head) < flow;
   }
 }
+

--- a/src/main/java/neqsim/process/equipment/compressor/SurgeCurve.java
+++ b/src/main/java/neqsim/process/equipment/compressor/SurgeCurve.java
@@ -1,159 +1,55 @@
 package neqsim.process.equipment.compressor;
 
-import java.util.Arrays;
-import java.util.Objects;
-import org.apache.commons.math3.analysis.polynomials.PolynomialFunction;
-import org.apache.commons.math3.fitting.PolynomialCurveFitter;
-import org.apache.commons.math3.fitting.WeightedObservedPoints;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * <p>
- * SurgeCurve class.
- * </p>
- *
- * @author asmund
- * @version $Id: $Id
+ * SurgeCurve defines the compressor surge limit.
  */
-public class SurgeCurve implements java.io.Serializable {
-  /** Serialization version UID. */
-  private static final long serialVersionUID = 1000;
+public class SurgeCurve extends BoundaryCurve {
+  private static final long serialVersionUID = 1000L;
   /** Logger object for class. */
   static Logger logger = LogManager.getLogger(SurgeCurve.class);
 
-  double[] flow;
-  double[] head;
-  double[] chartConditions = null;
-  private boolean isActive = false;
-
-  final WeightedObservedPoints flowFitter = new WeightedObservedPoints();
-  PolynomialFunction flowFitterFunc = null;
+  /** Default constructor. */
+  public SurgeCurve() {
+    super();
+  }
 
   /**
-   * <p>
-   * Constructor for SurgeCurve.
-   * </p>
-   */
-  public SurgeCurve() {}
-
-  /**
-   * <p>
-   * Constructor for SurgeCurve.
-   * </p>
+   * Create a surge curve from flow and head arrays.
    *
-   * @param flow an array of type double
-   * @param head an array of type double
+   * @param flow array of flow values
+   * @param head array of head values
    */
   public SurgeCurve(double[] flow, double[] head) {
-    this.flow = flow;
-    this.head = head;
-    this.setCurve(null, flow, head);
+    super(flow, head);
   }
 
   /**
-   * <p>
-   * setCurve.
-   * </p>
+   * Get the surge flow for a given head.
    *
-   * @param chartConditions an array of type double
-   * @param flow an array of type double
-   * @param head an array of type double
-   */
-  public void setCurve(double[] chartConditions, double[] flow, double[] head) {
-    this.flow = flow;
-    this.head = head;
-    this.chartConditions = chartConditions;
-    for (int i = 0; i < flow.length; i++) {
-      flowFitter.add(head[i], flow[i]);
-    }
-    PolynomialCurveFitter fitter = PolynomialCurveFitter.create(2);
-    flowFitterFunc = new PolynomialFunction(fitter.fit(flowFitter.toList()));
-    isActive = true;
-
-    // trykkforhold paa y-aksen mot redused flow
-    // dp over sugetrykk
-    // surge kurva er invariat i plottet trykkforhold mot redused flow
-    // CCC bruker dP/ (over maaleblnde som representerer flow) dP/Ps - paa x-aksen
-    // trykkforhold paa y-aksen (trykk ut/trykk inn)
-  }
-
-  /**
-   * <p>
-   * getSurgeFlow.
-   * </p>
-   *
-   * @param head a double
-   * @return a double
+   * @param head head value
+   * @return surge flow
    */
   public double getSurgeFlow(double head) {
-    return flowFitterFunc.value(head);
+    return getFlow(head);
   }
 
   /**
-   * <p>
-   * isSurge.
-   * </p>
+   * Check if the given point is in surge.
    *
-   * @param head a double
-   * @param flow a double
-   * @return a boolean
+   * @param head head value
+   * @param flow flow value
+   * @return true if the point is in surge
    */
   public boolean isSurge(double head, double flow) {
-    if (getSurgeFlow(head) > flow) {
-      return true;
-    } else {
-      return false;
-    }
+    return isLimit(head, flow);
   }
 
-  /**
-   * Getter for property isActive.
-   *
-   * @return boolean
-   */
-  boolean isActive() {
-    return isActive;
-  }
-
-  /**
-   * Setter for property isActive.
-   *
-   * @param isActive true if surge curve should be used for compressor calculations
-   */
-  void setActive(boolean isActive) {
-    this.isActive = isActive;
-  }
-
-  /** {@inheritDoc} */
   @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + Arrays.hashCode(chartConditions);
-    result = prime * result + Arrays.hashCode(flow);
-    result = prime * result + Arrays.hashCode(head);
-    result = prime * result + Objects.hash(flowFitterFunc, isActive);
-    // result = prime * result + Objects.hash(flowFitter);
-    return result;
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj == null) {
-      return false;
-    }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    SurgeCurve other = (SurgeCurve) obj;
-    return Arrays.equals(chartConditions, other.chartConditions) && Arrays.equals(flow, other.flow)
-        && Objects.equals(flowFitterFunc, other.flowFitterFunc) && Arrays.equals(head, other.head)
-        && isActive == other.isActive;
-    // && Objects.equals(flowFitter, other.flowFitter)
+  public boolean isLimit(double head, double flow) {
+    return getFlow(head) > flow;
   }
 }
+


### PR DESCRIPTION
## Summary
- add `BoundaryCurveInterface` and `BoundaryCurve` base implementation
- refactor surge and stonewall curves to extend the new base and share logic
- update SafeSpline variants to inherit from the refactored curves

## Testing
- `mvn -e -DskipTests package | tail -n 20`
- `mvn -e -Dtest=SafeSplineSurgeCurveTest test | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68938fc2a638832da5fea333fd806be0