### PR TITLE
Add FuelCell unit operation

### DIFF
--- a/src/main/java/neqsim/process/equipment/EquipmentEnum.java
+++ b/src/main/java/neqsim/process/equipment/EquipmentEnum.java
@@ -8,7 +8,7 @@ package neqsim.process.equipment;
  * @author esol
  */
 public enum EquipmentEnum {
-  Stream, ThrottlingValve, Compressor, Pump, Separator, HeatExchanger, Cooler, Heater, Mixer, Splitter, Reactor, Column, ThreePhaseSeparator, Recycle, Ejector, GORfitter, Adjuster, SetPoint, FlowRateAdjuster, Calculator, Expander, SimpleTEGAbsorber, Tank, ComponentSplitter, ReservoirCVDsim, ReservoirDiffLibsim, VirtualStream, ReservoirTPsim, SimpleReservoir, Manifold, Flare, FlareStack;
+  Stream, ThrottlingValve, Compressor, Pump, Separator, HeatExchanger, Cooler, Heater, Mixer, Splitter, Reactor, Column, ThreePhaseSeparator, Recycle, Ejector, GORfitter, Adjuster, SetPoint, FlowRateAdjuster, Calculator, Expander, SimpleTEGAbsorber, Tank, ComponentSplitter, ReservoirCVDsim, ReservoirDiffLibsim, VirtualStream, ReservoirTPsim, SimpleReservoir, Manifold, Flare, FlareStack, FuelCell;
 
   /** {@inheritDoc} */
   @Override

--- a/src/main/java/neqsim/process/equipment/powergeneration/FuelCell.java
+++ b/src/main/java/neqsim/process/equipment/powergeneration/FuelCell.java
@@ -1,0 +1,157 @@
+package neqsim.process.equipment.powergeneration;
+
+import java.util.UUID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.process.equipment.TwoPortEquipment;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * <p>
+ * FuelCell class representing a simple hydrogen fuel cell.
+ * </p>
+ *
+ * @author OpenAI
+ */
+public class FuelCell extends TwoPortEquipment {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1000;
+  /** Logger object for class. */
+  static Logger logger = LogManager.getLogger(FuelCell.class);
+
+  private StreamInterface oxidantStream;
+  private double efficiency = 0.6;
+  private double power = 0.0;
+  private double heatLoss = 0.0;
+
+  /**
+   * <p>
+   * Constructor for FuelCell.
+   * </p>
+   */
+  public FuelCell() {
+    this("FuelCell");
+  }
+
+  /**
+   * <p>
+   * Constructor for FuelCell.
+   * </p>
+   *
+   * @param name name of unit operation
+   */
+  public FuelCell(String name) {
+    super(name);
+  }
+
+  /**
+   * <p>
+   * Constructor for FuelCell.
+   * </p>
+   *
+   * @param name name of unit operation
+   * @param fuelStream inlet fuel stream
+   * @param oxidantStream inlet oxidant stream
+   */
+  public FuelCell(String name, StreamInterface fuelStream, StreamInterface oxidantStream) {
+    super(name, fuelStream);
+    this.oxidantStream = oxidantStream;
+  }
+
+  /**
+   * <p>Setter for the field <code>oxidantStream</code>.</p>
+   *
+   * @param stream oxidant stream
+   */
+  public void setOxidantStream(StreamInterface stream) {
+    this.oxidantStream = stream;
+  }
+
+  /**
+   * <p>Getter for the field <code>oxidantStream</code>.</p>
+   *
+   * @return oxidant stream
+   */
+  public StreamInterface getOxidantStream() {
+    return oxidantStream;
+  }
+
+  /**
+   * <p>Setter for the field <code>efficiency</code>.</p>
+   *
+   * @param efficiency electrical efficiency of the cell
+   */
+  public void setEfficiency(double efficiency) {
+    this.efficiency = efficiency;
+  }
+
+  /**
+   * <p>Getter for the field <code>efficiency</code>.</p>
+   *
+   * @return efficiency of the cell
+   */
+  public double getEfficiency() {
+    return efficiency;
+  }
+
+  /**
+   * <p>Getter for the field <code>power</code>.</p>
+   *
+   * @return electrical power produced [W]
+   */
+  public double getPower() {
+    return power;
+  }
+
+  /**
+   * <p>Getter for the field <code>heatLoss</code>.</p>
+   *
+   * @return heat lost from the cell [W]
+   */
+  public double getHeatLoss() {
+    return heatLoss;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void run(UUID id) {
+    SystemInterface system = inStream.getThermoSystem().clone();
+    if (oxidantStream != null) {
+      system.addFluid(oxidantStream.getThermoSystem());
+    }
+
+    double h2 = 0.0;
+    if (system.hasComponent("hydrogen")) {
+      h2 = system.getComponent("hydrogen").getNumberOfmoles();
+    }
+    double o2 = 0.0;
+    if (system.hasComponent("oxygen")) {
+      o2 = system.getComponent("oxygen").getNumberOfmoles();
+    }
+
+    double consumedH2 = Math.min(h2, 2.0 * o2);
+    double consumedO2 = consumedH2 / 2.0;
+
+    if (consumedH2 > 0) {
+      system.addComponent("water", consumedH2);
+      if (system.hasComponent("hydrogen")) {
+        system.addComponent("hydrogen", -consumedH2);
+      }
+      if (system.hasComponent("oxygen")) {
+        system.addComponent("oxygen", -consumedO2);
+      }
+    }
+
+    system.init(3);
+    outStream.setThermoSystem(system);
+
+    double fuelEnergy = inStream.LCV() * inStream.getFlowRate("mole/sec");
+    power = efficiency * fuelEnergy;
+    heatLoss = fuelEnergy - power;
+
+    getEnergyStream().setDuty(-power);
+    setCalculationIdentifier(id);
+  }
+}
+

--- a/src/test/java/neqsim/process/equipment/powergeneration/FuelCellTest.java
+++ b/src/test/java/neqsim/process/equipment/powergeneration/FuelCellTest.java
@@ -1,0 +1,42 @@
+package neqsim.process.equipment.powergeneration;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemSrkEos;
+
+public class FuelCellTest extends neqsim.NeqSimTest {
+  static Stream fuel;
+  static Stream oxidant;
+
+  @BeforeAll
+  static void setUp() {
+    SystemSrkEos fuelSys = new SystemSrkEos(298.15, 1.0);
+    fuelSys.addComponent("hydrogen", 2.0);
+    fuel = new Stream("fuel", fuelSys);
+    fuel.setFlowRate(1.0, "kg/hr");
+    fuel.setTemperature(298.15, "K");
+    fuel.setPressure(1.0, "bara");
+
+    SystemSrkEos oxSys = new SystemSrkEos(298.15, 1.0);
+    oxSys.addComponent("oxygen", 1.0);
+    oxidant = new Stream("oxidant", oxSys);
+    oxidant.setFlowRate(1.0, "kg/hr");
+    oxidant.setTemperature(298.15, "K");
+    oxidant.setPressure(1.0, "bara");
+  }
+
+  @Test
+  void testRun() {
+    fuel.run();
+    oxidant.run();
+
+    FuelCell cell = new FuelCell("cell", fuel, oxidant);
+    cell.setEfficiency(0.5);
+    cell.run();
+
+    assertTrue(cell.getEnergyStream().getDuty() < 0.0);
+    assertTrue(cell.getOutletStream().getFluid().hasComponent("water"));
+  }
+}


### PR DESCRIPTION
## Summary
- introduce FuelCell equipment that consumes hydrogen and oxidant streams to produce water and electrical power
- register FuelCell in EquipmentEnum
- cover FuelCell behaviour with unit test

## Testing
- `mvn -Dtest=FuelCellTest test`


------
https://chatgpt.com/codex/tasks/task_e_68a80c0a2abc832d8ba7f9ce490eceef