### PR TITLE
Add reference transport correlations for CO2

### DIFF
--- a/src/main/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/conductivity/CO2ConductivityMethod.java
+++ b/src/main/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/conductivity/CO2ConductivityMethod.java
@@ -1,0 +1,57 @@
+package neqsim.physicalproperties.methods.commonphasephysicalproperties.conductivity;
+
+import neqsim.physicalproperties.system.PhysicalProperties;
+
+/**
+ * Reference thermal conductivity correlation for pure carbon dioxide.
+ * Based on correlations by Huber (JPCRD 2016) and Scalabrin (JPCRD 2006).
+ */
+public class CO2ConductivityMethod extends Conductivity {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1000;
+
+  /**
+   * <p>Constructor for CO2ConductivityMethod.</p>
+   *
+   * @param phase a {@link neqsim.physicalproperties.system.PhysicalProperties} object
+   */
+  public CO2ConductivityMethod(PhysicalProperties phase) {
+    super(phase);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double calcConductivity() {
+    if (phase.getPhase().getNumberOfComponents() > 1
+        || !phase.getPhase().getComponent(0).getName().equalsIgnoreCase("CO2")) {
+      throw new Error("CO2 conductivity model only supports PURE CO2.");
+    }
+
+    double T = phase.getPhase().getTemperature();
+    double rho = phase.getDensity();
+
+    // Dilute gas term from Huber 2016 Eq. (3)
+    double Tc = 304.1282;
+    double tau = Tc / T;
+    double[] l = {0.0151874307, 0.0280674040, 0.0228564190, -0.00741624210};
+    double lambda0 = Math.pow(tau, -0.5)
+        / (l[0] + l[1] * tau + l[2] * Math.pow(tau, 2.0) + l[3] * Math.pow(tau, 3.0));
+    lambda0 /= 1000.0; // [W/mK]
+
+    // Critical enhancement from Scalabrin 2006
+    double nc = 0.775547504e-3 * 4.81384;
+    double Tr = T / Tc;
+    double rhor = rho / 467.6;
+    double[] a = {0.0, 3.0, 6.70697, 0.94604, 0.30, 0.30, 0.39751, 0.33791, 0.77963, 0.79857, 0.90, 0.02, 0.20};
+    double acoshArg = 1 + a[11] * Math.pow(Math.pow(1 - Tr, 2.0), a[12]);
+    double alpha = 1 - a[10] * Math.log(acoshArg + Math.sqrt(acoshArg - 1.0) * Math.sqrt(acoshArg + 1.0));
+    double numer = rhor * Math.exp(-Math.pow(rhor, a[1]) / a[1]
+        - Math.pow(a[2] * (Tr - 1), 2.0) - Math.pow(a[3] * (rhor - 1), 2.0));
+    double braced = (1 - 1 / Tr) + a[4] * Math.pow(Math.pow(rhor - 1, 2.0), 0.5 / a[5]);
+    double denom = Math.pow(Math.pow(Math.pow(braced, 2.0), a[6])
+        + Math.pow(Math.pow(a[7] * (rhor - alpha), 2.0), a[8]), a[9]);
+    double lambdaC = nc * numer / denom;
+
+    return lambda0 + lambdaC;
+  }
+}

--- a/src/main/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/viscosity/CO2ViscosityMethod.java
+++ b/src/main/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/viscosity/CO2ViscosityMethod.java
@@ -1,0 +1,59 @@
+package neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity;
+
+import neqsim.physicalproperties.system.PhysicalProperties;
+
+/**
+ * Reference viscosity correlation for pure carbon dioxide.
+ * Based on correlations by Laesecke et al. (JPCRD 2017).
+ */
+public class CO2ViscosityMethod extends Viscosity {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1000;
+
+  /**
+   * <p>Constructor for CO2ViscosityMethod.</p>
+   *
+   * @param phase a {@link neqsim.physicalproperties.system.PhysicalProperties} object
+   */
+  public CO2ViscosityMethod(PhysicalProperties phase) {
+    super(phase);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double calcViscosity() {
+    if (phase.getPhase().getNumberOfComponents() > 1
+        || !phase.getPhase().getComponent(0).getName().equalsIgnoreCase("CO2")) {
+      throw new Error("CO2 viscosity model only supports PURE CO2.");
+    }
+
+    double T = phase.getPhase().getTemperature();
+    double rho = phase.getDensity();
+
+    // Dilute-gas term (Laesecke JPCRD 2017 Eq. 4)
+    double[] a = {1749.354893188350, -369.069300007128, 5423856.34887691,
+        -2.21283852168356, -269503.247933569, 73145.021531826, 5.34368649509278};
+    double T13 = Math.pow(T, 1.0 / 3.0);
+    double T16 = Math.pow(T, 1.0 / 6.0);
+    double den = a[0] + a[1] * T16 + a[2] * Math.exp(a[3] * T13)
+        + (a[4] + a[5] * T13) / Math.exp(T13) + a[6] * Math.sqrt(T);
+    double eta0 = 0.0010055 * Math.sqrt(T) / den; // [Pa*s]
+
+    // Residual term (Laesecke JPCRD 2017 Eq. 8-9)
+    double c1 = 0.360603235428487;
+    double c2 = 0.121550806591497;
+    double gamma = 8.06282737481277;
+    double Tt = 216.592; // Triple point temperature [K]
+    double rho_tL = 1178.53; // Triple point liquid density [kg/m3]
+    double Tr = T / Tt;
+    double rhor = rho / rho_tL;
+    double R = 8.314462618; // Gas constant [J/mol/K]
+    double M = phase.getPhase().getComponent(0).getMolarMass(); // [kg/mol]
+    double eta_tL = Math.pow(rho_tL, 2.0 / 3.0) * Math.sqrt(R * Tt)
+        / (Math.pow(M, 1.0 / 6.0) * 84446887.43579945);
+    double residual = eta_tL
+        * (c1 * Tr * Math.pow(rhor, 3.0) + (Math.pow(rhor, 2.0) + Math.pow(rhor, gamma)) / (Tr - c2));
+
+    return eta0 + residual;
+  }
+}

--- a/src/main/java/neqsim/physicalproperties/system/PhysicalProperties.java
+++ b/src/main/java/neqsim/physicalproperties/system/PhysicalProperties.java
@@ -10,12 +10,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.physicalproperties.PhysicalPropertyType;
 import neqsim.physicalproperties.methods.commonphasephysicalproperties.conductivity.PFCTConductivityMethodMod86;
+import neqsim.physicalproperties.methods.commonphasephysicalproperties.conductivity.CO2ConductivityMethod;
 import neqsim.physicalproperties.methods.commonphasephysicalproperties.diffusivity.CorrespondingStatesDiffusivity;
 import neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity.FrictionTheoryViscosityMethod;
 import neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity.KTAViscosityMethod;
 import neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity.KTAViscosityMethodMod;
 import neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity.LBCViscosityMethod;
 import neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity.MethaneViscosityMethod;
+import neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity.CO2ViscosityMethod;
 import neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity.MuznyModViscosityMethod;
 import neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity.MuznyViscosityMethod;
 import neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity.PFCTViscosityMethodHeavyOil;
@@ -195,6 +197,8 @@ public abstract class PhysicalProperties implements Cloneable, ThermodynamicCons
               this);
     } else if ("Chung".equals(model)) {
       conductivityCalc = new ChungConductivityMethod(this);
+    } else if ("CO2Model".equals(model)) {
+      conductivityCalc = new CO2ConductivityMethod(this);
     } else {
       conductivityCalc = new PFCTConductivityMethodMod86(this);
     }
@@ -229,6 +233,8 @@ public abstract class PhysicalProperties implements Cloneable, ThermodynamicCons
       viscosityCalc = new MuznyModViscosityMethod(this);
     } else if ("MethaneModel".equals(model)) {
       viscosityCalc = new MethaneViscosityMethod(this);
+    } else if ("CO2Model".equals(model)) {
+      viscosityCalc = new CO2ViscosityMethod(this);
     } else if ("Salt Water".equals(model)) {
       viscosityCalc =
           new neqsim.physicalproperties.methods.liquidphysicalproperties.viscosity.Water(this);

--- a/src/test/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/conductivity/CO2ConductivityMethodTest.java
+++ b/src/test/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/conductivity/CO2ConductivityMethodTest.java
@@ -1,0 +1,23 @@
+package neqsim.physicalproperties.methods.commonphasephysicalproperties.conductivity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+public class CO2ConductivityMethodTest {
+  static neqsim.thermo.system.SystemInterface testSystem = null;
+
+  @Test
+  void testCalcConductivity() {
+    double T = 300.0;
+    double P = 1.0; // Pressure in bar
+    testSystem = new neqsim.thermo.system.SystemSrkEos(T, P);
+    testSystem.addComponent("CO2", 1.0);
+    ThermodynamicOperations ops = new ThermodynamicOperations(testSystem);
+    ops.TPflash();
+    testSystem.getPhase("gas").getPhysicalProperties().setConductivityModel("CO2Model");
+    testSystem.initProperties();
+    assertEquals(0.016728951577544077,
+        testSystem.getPhase(0).getPhysicalProperties().getConductivity(), 1e-6);
+  }
+}

--- a/src/test/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/viscosity/CO2ViscosityMethodTest.java
+++ b/src/test/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/viscosity/CO2ViscosityMethodTest.java
@@ -1,0 +1,23 @@
+package neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+public class CO2ViscosityMethodTest {
+  static neqsim.thermo.system.SystemInterface testSystem = null;
+
+  @Test
+  void testCalcViscosity() {
+    double T = 300.0;
+    double P = 1.0; // Pressure in bar
+    testSystem = new neqsim.thermo.system.SystemSrkEos(T, P);
+    testSystem.addComponent("CO2", 1.0);
+    ThermodynamicOperations ops = new ThermodynamicOperations(testSystem);
+    ops.TPflash();
+    testSystem.getPhase("gas").getPhysicalProperties().setViscosityModel("CO2Model");
+    testSystem.initProperties();
+    assertEquals(1.4993960815994241E-5,
+        testSystem.getPhase(0).getPhysicalProperties().getViscosity(), 1e-9);
+  }
+}


### PR DESCRIPTION
## Summary
- implement Laesecke-based reference viscosity equation for pure CO2
- implement Huber/Scalabrin reference thermal conductivity equation for pure CO2
- expose CO2-specific transport models and cover with unit tests

## Testing
- `mvn -q -Dtest=CO2ViscosityMethodTest,CO2ConductivityMethodTest test`


------
https://chatgpt.com/codex/tasks/task_e_68a8e1f54664832da6ed94772488feb5