### PR TITLE
feat: add relaxed distillation column solver

### DIFF
--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -19,6 +19,11 @@ This document outlines how the `DistillationColumn` class in NeqSim solves a mul
    - After each iteration the sum of absolute temperature changes on all trays is used as the convergence measure.
    - Iterations stop when the error falls below `1e-4` or the maximum number of iterations is reached.
 
+   The class also supports a damped variant of the sequential substitution algorithm.
+   The default `SolverType` is `DIRECT_SUBSTITUTION`, but you may activate the damped
+   solver by calling `setSolverType(SolverType.DAMPED_SUBSTITUTION)` and optionally
+   tune the relaxation factor via `setRelaxationFactor(double)`.
+
 4. **Results**
    - Once converged the gas stream from the top tray and the liquid stream from the bottom tray are reported as product streams.
 

--- a/src/test/java/neqsim/process/equipment/distillation/DistillationColumnTest.java
+++ b/src/test/java/neqsim/process/equipment/distillation/DistillationColumnTest.java
@@ -6,6 +6,7 @@ import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkCPAstatoil;
+import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
 public class DistillationColumnTest {
@@ -324,6 +325,29 @@ public class DistillationColumnTest {
     column.addFeedStream(feed, 1);
     column.runBroyden(java.util.UUID.randomUUID());
 
+
+    assertEquals(true, column.solved());
+  }
+
+  /**
+   * Basic check that the damped solver converges on a simple system.
+   */
+  @Test
+  public void testDampedSolver() {
+    SystemInterface simpleSystem = new SystemSrkEos(298.15, 5.0);
+    simpleSystem.addComponent("methane", 1.0);
+    simpleSystem.addComponent("ethane", 1.0);
+    simpleSystem.createDatabase(true);
+    simpleSystem.setMixingRule("classic");
+
+    Stream feed = new Stream("feed", simpleSystem);
+    feed.run();
+
+    DistillationColumn column = new DistillationColumn("test column", 1, true, true);
+    column.addFeedStream(feed, 1);
+    column.setSolverType(DistillationColumn.SolverType.DAMPED_SUBSTITUTION);
+    column.setRelaxationFactor(0.5);
+    column.run();
 
     assertEquals(true, column.solved());
   }


### PR DESCRIPTION
## Summary
- add configurable solver selection for distillation columns
- document solver configuration and default behavior
- test damped solver convergence

## Testing
- `mvn -e -Dtest=DistillationColumnTest test`


------
https://chatgpt.com/codex/tasks/task_e_68a8eacbd1e8832d8d8497ee293b33bf