### PR TITLE
Normalize temperature conversions through Kelvin

### DIFF
--- a/src/main/java/neqsim/util/unit/TemperatureUnit.java
+++ b/src/main/java/neqsim/util/unit/TemperatureUnit.java
@@ -19,9 +19,11 @@ public class TemperatureUnit extends neqsim.util.unit.BaseUnit {
    *
    * @param value a double
    * @param name a {@link java.lang.String} object
-   */
+  */
   public TemperatureUnit(double value, String name) {
     super(value, name);
+    // store the temperature in Kelvin for reuse
+    this.SIvalue = getValue(value, name, "K");
   }
 
   /**
@@ -93,21 +95,19 @@ public class TemperatureUnit extends neqsim.util.unit.BaseUnit {
    */
   @Override
   public double getValue(String toUnit) {
+    // convert the original value to Kelvin and reuse for subsequent conversions
+    double tempInKelvin = SIvalue;
+
     switch (toUnit) {
       case "K":
-        // Convert from Kelvin to Kelvin
-        return invalue;
+        return tempInKelvin;
       case "C":
-        // Convert from Kelvin to Celsius
-        return invalue - 273.15;
+        return tempInKelvin - 273.15;
       case "F":
-        // Convert from Kelvin to Fahrenheit
-        return invalue * 9.0 / 5.0 - 459.67;
+        return (tempInKelvin - 273.15) * 9.0 / 5.0 + 32;
       case "R":
-        // Convert from Kelvin to Rankine
-        return invalue * 9.0 / 5.0;
+        return tempInKelvin * 9.0 / 5.0;
       default:
-        // Handle unsupported units
         throw new IllegalArgumentException("Unsupported conversion unit: " + toUnit);
     }
   }

--- a/src/test/java/neqsim/util/unit/TemperatureUnitTest.java
+++ b/src/test/java/neqsim/util/unit/TemperatureUnitTest.java
@@ -52,13 +52,41 @@ class TemperatureUnitTest extends neqsim.NeqSimTest {
   }
 
   /**
+   * Verify direct temperature conversions between common units.
+   */
+  @Test
+  public void testDirectConversions() {
+    // 100 C to other units
+    TemperatureUnit celsius = new TemperatureUnit(100.0, "C");
+    assertEquals(373.15, celsius.getValue("K"), 1e-6);
+    assertEquals(212.0, celsius.getValue("F"), 1e-6);
+    assertEquals(671.67, celsius.getValue("R"), 1e-2);
+
+    // 373.15 K to Celsius and Fahrenheit
+    TemperatureUnit kelvin = new TemperatureUnit(373.15, "K");
+    assertEquals(100.0, kelvin.getValue("C"), 1e-6);
+    assertEquals(212.0, kelvin.getValue("F"), 1e-6);
+
+    // 212 F to Kelvin and Celsius
+    TemperatureUnit fahrenheit = new TemperatureUnit(212.0, "F");
+    assertEquals(373.15, fahrenheit.getValue("K"), 1e-6);
+    assertEquals(100.0, fahrenheit.getValue("C"), 1e-6);
+
+    // 671.67 R to Celsius and Kelvin
+    TemperatureUnit rankine = new TemperatureUnit(671.67, "R");
+    assertEquals(373.15, rankine.getValue("K"), 1e-2);
+    assertEquals(100.0, rankine.getValue("C"), 1e-2);
+  }
+
+  /**
    * Verify that requesting conversions with unsupported units throws an exception.
    */
   @Test
   public void testUnsupportedUnit() {
-    TemperatureUnit unit = new TemperatureUnit(0.0, "test");
+    TemperatureUnit unit = new TemperatureUnit(0.0, "K");
     assertThrows(IllegalArgumentException.class, () -> unit.getValue(0.0, "X", "K"));
     assertThrows(IllegalArgumentException.class, () -> unit.getValue(0.0, "K", "X"));
+    assertThrows(IllegalArgumentException.class, () -> new TemperatureUnit(0.0, "X"));
   }
 }
 


### PR DESCRIPTION
## Summary
- Ensure `TemperatureUnit` stores Kelvin on construction and converts via Kelvin for all unit transformations
- Add comprehensive unit tests for conversions among K, °C, °F, and °R

## Testing
- `mvn -e -Dtest=TemperatureUnitTest test`


------
https://chatgpt.com/codex/tasks/task_e_68acb6312a34832da1d1e6fdf60ea473