### PR TITLE
Fix logical OR usage in RateUnit

### DIFF
--- a/src/main/java/neqsim/util/unit/RateUnit.java
+++ b/src/main/java/neqsim/util/unit/RateUnit.java
@@ -89,11 +89,11 @@ public class RateUnit extends neqsim.util.unit.BaseUnit {
       factor = 1.0 / molarmass / 3600.0;
     } else if (name.equals("kg/day")) {
       factor = 1.0 / molarmass / (3600.0 * 24.0);
-    } else if (name.equals("Sm^3/sec") | name.equals("Sm3/sec")) {
+    } else if (name.equals("Sm^3/sec") || name.equals("Sm3/sec")) {
       factor = mol_Sm3;
-    } else if (name.equals("Sm^3/min") | name.equals("Sm3/min")) {
+    } else if (name.equals("Sm^3/min") || name.equals("Sm3/min")) {
       factor = 1.0 / 60.0 * mol_Sm3;
-    } else if (name.equals("Sm^3/hr") | name.equals("Sm3/hr")) {
+    } else if (name.equals("Sm^3/hr") || name.equals("Sm3/hr")) {
       factor = 1.0 / 60.0 / 60.0 * mol_Sm3;
     } else if (name.equals("Sm^3/day") || name.equals("Sm3/day")) {
       factor = 1.0 / 60.0 / 60.0 / 24.0 * mol_Sm3;


### PR DESCRIPTION
## Summary
- use short-circuit logical OR for Sm^3 unit comparisons in RateUnit

## Testing
- `mvn -q test` (fails: No data is available [2000-232])

------
https://chatgpt.com/codex/tasks/task_e_68acb6394a48832d997f679b5a754d97