### PR TITLE
feat: support equipment-specific report detail

### DIFF
--- a/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
+++ b/src/main/java/neqsim/process/equipment/ProcessEquipmentBaseClass.java
@@ -19,6 +19,8 @@ import neqsim.process.controllerdevice.ControllerDeviceInterface;
 import neqsim.process.equipment.stream.EnergyStream;
 import neqsim.process.mechanicaldesign.MechanicalDesign;
 import neqsim.process.util.report.Report;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
@@ -320,6 +322,14 @@ public abstract class ProcessEquipmentBaseClass extends SimulationBaseClass
   @Override
   public String toJson() {
     return null;
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    return toJson();
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/ProcessEquipmentInterface.java
+++ b/src/main/java/neqsim/process/equipment/ProcessEquipmentInterface.java
@@ -4,6 +4,8 @@ import neqsim.process.SimulationInterface;
 import neqsim.process.controllerdevice.ControllerDeviceInterface;
 import neqsim.process.mechanicaldesign.MechanicalDesign;
 import neqsim.thermo.system.SystemInterface;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 
 /**
  * <p>
@@ -248,6 +250,19 @@ public interface ProcessEquipmentInterface extends SimulationInterface {
    * @return json string.
    */
   public String toJson();
+
+  /**
+   * Serializes the Process Equipment with configurable level of detail.
+   *
+   * @param cfg report configuration
+   * @return json string
+   */
+  public default String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    return toJson();
+  }
 
   /** {@inheritDoc} */
   @Override

--- a/src/main/java/neqsim/process/equipment/TwoPortEquipment.java
+++ b/src/main/java/neqsim/process/equipment/TwoPortEquipment.java
@@ -1,6 +1,8 @@
 package neqsim.process.equipment;
 
 import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 
 /**
  * Abstract class defining ProcessEquipment with one inlet and one outlet.
@@ -112,5 +114,13 @@ public abstract class TwoPortEquipment extends ProcessEquipmentBaseClass
   @Override
   public String toJson() {
     return null;
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    return toJson();
   }
 }

--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -18,6 +18,8 @@ import neqsim.process.equipment.TwoPortEquipment;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.mechanicaldesign.compressor.CompressorMechanicalDesign;
 import neqsim.process.util.monitor.CompressorResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.thermo.ThermodynamicConstantsInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -1832,6 +1834,16 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface 
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new CompressorResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    CompressorResponse res = new CompressorResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
+++ b/src/main/java/neqsim/process/equipment/distillation/DistillationColumn.java
@@ -16,6 +16,8 @@ import neqsim.process.equipment.separator.Separator;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.util.monitor.DistillationColumnResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
@@ -1165,6 +1167,16 @@ public class DistillationColumn extends ProcessEquipmentBaseClass implements Dis
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new DistillationColumnResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    DistillationColumnResponse res = new DistillationColumnResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/expander/TurboExpanderCompressor.java
+++ b/src/main/java/neqsim/process/equipment/expander/TurboExpanderCompressor.java
@@ -6,6 +6,8 @@ import com.google.gson.GsonBuilder;
 import neqsim.process.equipment.compressor.Compressor;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.util.monitor.TurboExpanderCompressorResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 
@@ -1095,6 +1097,16 @@ public class TurboExpanderCompressor extends Expander {
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new TurboExpanderCompressorResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    TurboExpanderCompressorResponse res = new TurboExpanderCompressorResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/heatexchanger/Cooler.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/Cooler.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 import com.google.gson.GsonBuilder;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.util.monitor.HeaterResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 
 /**
  * <p>
@@ -59,5 +61,15 @@ public class Cooler extends Heater {
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new HeaterResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    HeaterResponse res = new HeaterResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 }

--- a/src/main/java/neqsim/process/equipment/heatexchanger/HeatExchanger.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/HeatExchanger.java
@@ -13,6 +13,8 @@ import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.util.monitor.HXResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
@@ -704,6 +706,16 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface {
   public String toJson() {
     return new GsonBuilder().serializeSpecialFloatingPointValues().create()
         .toJson(new HXResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    HXResponse res = new HXResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().serializeSpecialFloatingPointValues().create().toJson(res);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/Heater.java
@@ -12,6 +12,8 @@ import neqsim.process.equipment.TwoPortEquipment;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.util.monitor.HeaterResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
@@ -399,5 +401,15 @@ public class Heater extends TwoPortEquipment implements HeaterInterface {
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new HeaterResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    HeaterResponse res = new HeaterResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 }

--- a/src/main/java/neqsim/process/equipment/heatexchanger/MultiStreamHeatExchanger.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/MultiStreamHeatExchanger.java
@@ -16,6 +16,8 @@ import neqsim.process.conditionmonitor.ConditionMonitorSpecifications;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.util.monitor.MultiStreamHeatExchangerResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
@@ -380,6 +382,16 @@ public class MultiStreamHeatExchanger extends Heater implements MultiStreamHeatE
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new MultiStreamHeatExchangerResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    MultiStreamHeatExchangerResponse res = new MultiStreamHeatExchangerResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/heatexchanger/MultiStreamHeatExchanger2.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/MultiStreamHeatExchanger2.java
@@ -16,6 +16,8 @@ import org.apache.logging.log4j.Logger;
 import com.google.gson.GsonBuilder;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.util.monitor.MultiStreamHeatExchanger2Response;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
@@ -1001,5 +1003,15 @@ public class MultiStreamHeatExchanger2 extends Heater implements MultiStreamHeat
   public String toJson() {
     return new GsonBuilder().serializeSpecialFloatingPointValues().create()
         .toJson(new MultiStreamHeatExchanger2Response(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    MultiStreamHeatExchanger2Response res = new MultiStreamHeatExchanger2Response(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().serializeSpecialFloatingPointValues().create().toJson(res);
   }
 }

--- a/src/main/java/neqsim/process/equipment/heatexchanger/MultiStreamHeatExchangerInterface.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/MultiStreamHeatExchangerInterface.java
@@ -1,6 +1,8 @@
 package neqsim.process.equipment.heatexchanger;
 
 import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.process.equipment.stream.StreamInterface;
 
 /**
@@ -260,6 +262,14 @@ public interface MultiStreamHeatExchangerInterface extends ProcessEquipmentInter
   /** {@inheritDoc} */
   @Override
   String toJson();
+
+  @Override
+  default String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    return toJson();
+  }
 
   // ================================
   // Additional Methods

--- a/src/main/java/neqsim/process/equipment/manifold/Manifold.java
+++ b/src/main/java/neqsim/process/equipment/manifold/Manifold.java
@@ -9,6 +9,8 @@ import neqsim.process.equipment.mixer.Mixer;
 import neqsim.process.equipment.splitter.Splitter;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.util.monitor.ManifoldResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 
 /**
  * <p>
@@ -119,5 +121,15 @@ public class Manifold extends ProcessEquipmentBaseClass {
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new ManifoldResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    ManifoldResponse res = new ManifoldResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 }

--- a/src/main/java/neqsim/process/equipment/mixer/Mixer.java
+++ b/src/main/java/neqsim/process/equipment/mixer/Mixer.java
@@ -21,6 +21,8 @@ import neqsim.thermo.system.SystemSoreideWhitson;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 import neqsim.process.util.monitor.MixerResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 
 /**
  * <p>
@@ -524,5 +526,15 @@ public class Mixer extends ProcessEquipmentBaseClass implements MixerInterface {
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new MixerResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    MixerResponse res = new MixerResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 }

--- a/src/main/java/neqsim/process/equipment/mixer/StaticMixer.java
+++ b/src/main/java/neqsim/process/equipment/mixer/StaticMixer.java
@@ -11,6 +11,8 @@ import com.google.gson.GsonBuilder;
 import neqsim.thermo.system.SystemSoreideWhitson;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.process.util.monitor.MixerResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 
 /**
  * <p>
@@ -142,5 +144,15 @@ public class StaticMixer extends Mixer {
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new MixerResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    MixerResponse res = new MixerResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 }

--- a/src/main/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrills.java
+++ b/src/main/java/neqsim/process/equipment/pipeline/PipeBeggsAndBrills.java
@@ -7,6 +7,8 @@ import java.util.UUID;
 import com.google.gson.GsonBuilder;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.util.monitor.PipeBeggsBrillsResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
@@ -1485,5 +1487,15 @@ public class PipeBeggsAndBrills extends Pipeline {
   public String toJson() {
     return new GsonBuilder().serializeSpecialFloatingPointValues().create()
         .toJson(new PipeBeggsBrillsResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    PipeBeggsBrillsResponse res = new PipeBeggsBrillsResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().serializeSpecialFloatingPointValues().create().toJson(res);
   }
 }

--- a/src/main/java/neqsim/process/equipment/pump/Pump.java
+++ b/src/main/java/neqsim/process/equipment/pump/Pump.java
@@ -13,6 +13,8 @@ import com.google.gson.GsonBuilder;
 import neqsim.process.equipment.TwoPortEquipment;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.util.monitor.PumpResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.thermo.ThermodynamicConstantsInterface;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -464,6 +466,16 @@ public class Pump extends TwoPortEquipment implements PumpInterface {
   public String toJson() {
     return new GsonBuilder().serializeSpecialFloatingPointValues().create()
         .toJson(new PumpResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    PumpResponse res = new PumpResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().serializeSpecialFloatingPointValues().create().toJson(res);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/separator/Separator.java
+++ b/src/main/java/neqsim/process/equipment/separator/Separator.java
@@ -24,6 +24,8 @@ import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.mechanicaldesign.separator.SeparatorMechanicalDesign;
 import neqsim.process.util.monitor.SeparatorResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSoreideWhitson;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -888,6 +890,16 @@ public class Separator extends ProcessEquipmentBaseClass implements SeparatorInt
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new SeparatorResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    SeparatorResponse res = new SeparatorResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 
   /*

--- a/src/main/java/neqsim/process/equipment/separator/ThreePhaseSeparator.java
+++ b/src/main/java/neqsim/process/equipment/separator/ThreePhaseSeparator.java
@@ -5,6 +5,8 @@ import com.google.gson.GsonBuilder;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.util.monitor.SeparatorResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 
@@ -276,5 +278,15 @@ public class ThreePhaseSeparator extends Separator {
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new SeparatorResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    SeparatorResponse res = new SeparatorResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 }

--- a/src/main/java/neqsim/process/equipment/stream/Stream.java
+++ b/src/main/java/neqsim/process/equipment/stream/Stream.java
@@ -16,6 +16,8 @@ import com.google.gson.GsonBuilder;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
 import neqsim.process.measurementdevice.HydrocarbonDewPointAnalyser;
 import neqsim.process.util.monitor.StreamResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.standards.gasquality.Standard_ISO6976;
 import neqsim.standards.oilquality.Standard_ASTM_D6377;
 import neqsim.thermo.system.SystemInterface;
@@ -775,5 +777,15 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new StreamResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    StreamResponse res = new StreamResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 }

--- a/src/main/java/neqsim/process/equipment/tank/Tank.java
+++ b/src/main/java/neqsim/process/equipment/tank/Tank.java
@@ -12,6 +12,8 @@ import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 import neqsim.process.util.monitor.TankResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 
 /**
  * <p>
@@ -460,5 +462,15 @@ public class Tank extends ProcessEquipmentBaseClass {
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new TankResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    TankResponse res = new TankResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 }

--- a/src/main/java/neqsim/process/equipment/util/Recycle.java
+++ b/src/main/java/neqsim/process/equipment/util/Recycle.java
@@ -12,6 +12,8 @@ import neqsim.thermodynamicoperations.ThermodynamicOperations;
 import neqsim.util.ExcludeFromJacocoGeneratedReport;
 import com.google.gson.GsonBuilder;
 import neqsim.process.util.monitor.RecycleResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 
 /**
  * <p>
@@ -682,5 +684,15 @@ public class Recycle extends ProcessEquipmentBaseClass implements MixerInterface
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new RecycleResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    RecycleResponse res = new RecycleResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 }

--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -10,6 +10,8 @@ import neqsim.process.equipment.TwoPortEquipment;
 import neqsim.process.equipment.stream.StreamInterface;
 import neqsim.process.mechanicaldesign.valve.ValveMechanicalDesign;
 import neqsim.process.util.monitor.ValveResponse;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -585,6 +587,16 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface 
   @Override
   public String toJson() {
     return new GsonBuilder().create().toJson(new ValveResponse(this));
+  }
+
+  @Override
+  public String toJson(ReportConfig cfg) {
+    if (cfg != null && cfg.getDetailLevel(getName()) == DetailLevel.HIDE) {
+      return null;
+    }
+    ValveResponse res = new ValveResponse(this);
+    res.applyConfig(cfg);
+    return new GsonBuilder().create().toJson(res);
   }
 
   /**

--- a/src/main/java/neqsim/process/util/monitor/BaseResponse.java
+++ b/src/main/java/neqsim/process/util/monitor/BaseResponse.java
@@ -2,6 +2,8 @@ package neqsim.process.util.monitor;
 
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.measurementdevice.MeasurementDeviceInterface;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 
 /**
  * <p>
@@ -45,5 +47,13 @@ public class BaseResponse {
   public BaseResponse(MeasurementDeviceInterface equipment) {
     tagName = equipment.getTagName();
     name = equipment.getName();
+  }
+
+  /** Apply reporting configuration - default does nothing. */
+  public void applyConfig(ReportConfig cfg) {}
+
+  /** Determine detail level for this response based on config. */
+  protected DetailLevel getDetailLevel(ReportConfig cfg) {
+    return cfg == null ? DetailLevel.FULL : cfg.getDetailLevel(name);
   }
 }

--- a/src/main/java/neqsim/process/util/monitor/CompressorResponse.java
+++ b/src/main/java/neqsim/process/util/monitor/CompressorResponse.java
@@ -1,6 +1,8 @@
 package neqsim.process.util.monitor;
 
 import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 
 /**
  * <p>
@@ -64,6 +66,31 @@ public class CompressorResponse extends BaseResponse {
     speed = inputCompressor.getSpeed();
     if (inputCompressor.getAntiSurge().isActive()) {
       internalVolumeFlow = inputCompressor.getCompressorChart().getSurgeCurve().getSurgeFlow(polytropicHead);
+    }
+  }
+
+  @Override
+  public void applyConfig(ReportConfig cfg) {
+    DetailLevel level = getDetailLevel(cfg);
+    if (level == DetailLevel.SUMMARY) {
+      polytropicHead = null;
+      polytropicEfficiency = null;
+      internalVolumeFlow = null;
+      speed = null;
+    } else if (level == DetailLevel.MINIMUM) {
+      polytropicHead = null;
+      polytropicEfficiency = null;
+      internalVolumeFlow = null;
+      speed = null;
+      suctionTemperature = null;
+      dischargeTemperature = null;
+      suctionVolumeFlow = null;
+      dischargeVolumeFlow = null;
+      molarMass = null;
+      suctionMassDensity = null;
+      dischargeMassDensity = null;
+      massflow = null;
+      stdFlow = null;
     }
   }
 }

--- a/src/main/java/neqsim/process/util/monitor/StreamResponse.java
+++ b/src/main/java/neqsim/process/util/monitor/StreamResponse.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.util.report.ReportConfig;
+import neqsim.process.util.report.ReportConfig.DetailLevel;
 import neqsim.standards.gasquality.Standard_ISO6976;
 
 /**
@@ -239,7 +241,38 @@ public class StreamResponse extends BaseResponse {
         newdata.put("gas flow",
             new Value(Double.toString(inputStream.getFlowRate("Sm3/hr")), "Sm3/hr"));
       }
-      properties.put(name, newdata);
+        properties.put(name, newdata);
+      }
+  }
+
+  @Override
+  public void applyConfig(ReportConfig cfg) {
+    DetailLevel level = getDetailLevel(cfg);
+    if (level == DetailLevel.SUMMARY) {
+      composition = null;
+      properties = null;
+    } else if (level == DetailLevel.MINIMUM) {
+      composition = null;
+      properties = null;
+      if (conditions != null) {
+        HashMap<String, Value> overall = conditions.get("overall");
+        if (overall != null) {
+          HashMap<String, Value> minimal = new HashMap<>();
+          if (overall.get("temperature") != null) {
+            minimal.put("temperature", overall.get("temperature"));
+          }
+          if (overall.get("pressure") != null) {
+            minimal.put("pressure", overall.get("pressure"));
+          }
+          if (overall.get("molar flow") != null) {
+            minimal.put("molar flow", overall.get("molar flow"));
+          }
+          conditions = new HashMap<>();
+          conditions.put("overall", minimal);
+        } else {
+          conditions = null;
+        }
+      }
     }
   }
 

--- a/src/main/java/neqsim/process/util/report/Report.java
+++ b/src/main/java/neqsim/process/util/report/Report.java
@@ -11,6 +11,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import neqsim.process.equipment.ProcessEquipmentBaseClass;
 import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.util.report.ReportConfig;
 import neqsim.process.processmodel.ProcessModel;
 import neqsim.process.processmodel.ProcessModule;
 import neqsim.process.processmodel.ProcessModuleBaseClass;
@@ -109,15 +110,31 @@ public class Report {
    * @return a {@link java.lang.String} object
    */
   public String generateJsonReport() {
+    return generateJsonReport(new ReportConfig());
+  }
+
+  /**
+   * Generate a JSON report with configurable detail level.
+   *
+   * @param cfg report configuration
+   * @return JSON string
+   */
+  public String generateJsonReport(ReportConfig cfg) {
     Map<String, String> json_reports = new HashMap<>();
 
     if (process != null) {
       for (ProcessEquipmentInterface unit : process.getUnitOperations()) {
-        json_reports.put(unit.getName(), unit.toJson());
+        String unitJson = unit.toJson(cfg);
+        if (unitJson != null) {
+          json_reports.put(unit.getName(), unitJson);
+        }
       }
     }
     if (processEquipment != null) {
-      json_reports.put(processEquipment.getName(), processEquipment.toJson());
+      String eqJson = processEquipment.toJson(cfg);
+      if (eqJson != null) {
+        json_reports.put(processEquipment.getName(), eqJson);
+      }
     }
     if (fluid != null) {
       json_reports.put(fluid.getFluidName(), fluid.toJson());
@@ -129,7 +146,7 @@ public class Report {
 
         for (ProcessEquipmentInterface unit : process.getUnitOperations()) {
           try {
-            String unitJson = unit.toJson();
+            String unitJson = unit.toJson(cfg);
             String unitName = unit.getName() != null ? unit.getName() : "UnnamedUnit";
 
             if (unitJson != null && !unitJson.isEmpty()) {

--- a/src/main/java/neqsim/process/util/report/ReportConfig.java
+++ b/src/main/java/neqsim/process/util/report/ReportConfig.java
@@ -1,0 +1,53 @@
+package neqsim.process.util.report;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Configuration options for JSON reporting.
+ */
+public class ReportConfig {
+  /** Level of detail to include in reports. */
+  public enum DetailLevel {
+    /** Include only tag/name and minimal key fields. */
+    MINIMUM,
+    /** Include a small subset of data, omitting composition and detailed properties. */
+    SUMMARY,
+    /** Include all available information. */
+    FULL,
+    /** Do not include the unit in reports. */
+    HIDE
+  }
+
+  /** Selected detail level. Defaults to FULL. */
+  public DetailLevel detailLevel = DetailLevel.FULL;
+
+  /** Optional overrides per equipment name. */
+  private Map<String, DetailLevel> unitDetailLevel = new HashMap<>();
+
+  public ReportConfig() {}
+
+  public ReportConfig(DetailLevel detailLevel) {
+    this.detailLevel = detailLevel;
+  }
+
+  /**
+   * Set detail level for a specific unit.
+   *
+   * @param unitName name of equipment
+   * @param level desired detail level
+   */
+  public void setDetailLevel(String unitName, DetailLevel level) {
+    unitDetailLevel.put(unitName, level);
+  }
+
+  /**
+   * Get detail level for a specific unit, falling back to the global level.
+   *
+   * @param unitName name of equipment
+   * @return detail level for the unit
+   */
+  public DetailLevel getDetailLevel(String unitName) {
+    return unitDetailLevel.getOrDefault(unitName, detailLevel);
+  }
+}


### PR DESCRIPTION
## Summary
- allow overriding report detail per equipment via `ReportConfig` and unit-level lookups
- streamline response helpers to resolve the appropriate detail level
- add MINIMUM and HIDE options so units can emit only basic info or be omitted entirely

## Testing
- `mvn -q -e test` *(fails: org.h2.jdbc.JdbcSQLNonTransientException: No data is available [2000-232])*

------
https://chatgpt.com/codex/tasks/task_e_68ab887e3fb4832dbc9b12cf684ec3f9