### PR TITLE
Implement basic GERG2008 EOS derivatives and test

### DIFF
--- a/src/main/java/neqsim/thermo/component/ComponentGERG2008Eos.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGERG2008Eos.java
@@ -1,5 +1,7 @@
 package neqsim.thermo.component;
 
+import neqsim.thermo.ThermodynamicConstantsInterface;
+import neqsim.thermo.phase.PhaseGERG2008Eos;
 import neqsim.thermo.phase.PhaseInterface;
 
 /**
@@ -115,28 +117,44 @@ public class ComponentGERG2008Eos extends ComponentEos {
   @Override
   public double dFdN(PhaseInterface phase, int numberOfComponents, double temperature,
       double pressure) {
-    return 0;
+    PhaseGERG2008Eos ph = (PhaseGERG2008Eos) phase;
+    double logXi = Math.log(getx());
+    double ideal = ph.getAlpha0() != null ? ph.getAlpha0()[0].val : 0.0;
+    double residual = ph.getAlphaRes() != null ? ph.getAlphaRes()[0][0].val : 0.0;
+    return logXi + ideal + residual;
   }
 
   /** {@inheritDoc} */
   @Override
   public double dFdNdN(int i, PhaseInterface phase, int numberOfComponents, double temperature,
       double pressure) {
-    return 0;
+    double term =
+        (getComponentNumber() == i ? 1.0 / phase.getNumberOfMolesInPhase() : 0.0);
+    PhaseGERG2008Eos ph = (PhaseGERG2008Eos) phase;
+    if (ph.getAlphaRes() != null) {
+      term += ph.getAlphaRes()[0][2].val / phase.getNumberOfMolesInPhase();
+    }
+    return term;
   }
 
   /** {@inheritDoc} */
   @Override
   public double dFdNdV(PhaseInterface phase, int numberOfComponents, double temperature,
       double pressure) {
-    return 0;
+    PhaseGERG2008Eos ph = (PhaseGERG2008Eos) phase;
+    double alphar = ph.getAlphaRes() != null ? ph.getAlphaRes()[0][1].val : 0.0;
+    return ThermodynamicConstantsInterface.R * temperature / phase.getVolume()
+        * (1.0 + alphar);
   }
 
   /** {@inheritDoc} */
   @Override
   public double dFdNdT(PhaseInterface phase, int numberOfComponents, double temperature,
       double pressure) {
-    return 0;
+    PhaseGERG2008Eos ph = (PhaseGERG2008Eos) phase;
+    double a0T = ph.getAlpha0() != null ? ph.getAlpha0()[1].val : 0.0;
+    double arT = ph.getAlphaRes() != null ? ph.getAlphaRes()[1][0].val : 0.0;
+    return -(a0T + arT) / temperature;
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/phase/PhaseGERG2008Eos.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseGERG2008Eos.java
@@ -227,4 +227,22 @@ public class PhaseGERG2008Eos extends PhaseEos {
   public double getdPdrho() {
     return R * temperature * (1 + 2 * ar[0][1].val + ar[0][2].val);
   }
+
+  /**
+   * Get cached ideal Helmholtz energy derivatives.
+   *
+   * @return array of {@link doubleW} containing \u03b1₀ and its derivatives
+   */
+  public doubleW[] getAlpha0() {
+    return a0;
+  }
+
+  /**
+   * Get cached residual Helmholtz energy derivatives.
+   *
+   * @return matrix of {@link doubleW} containing \u03b1ᵣ and its derivatives
+   */
+  public doubleW[][] getAlphaRes() {
+    return ar;
+  }
 }

--- a/src/test/java/neqsim/thermo/phase/PhaseGERG2008EosTest.java
+++ b/src/test/java/neqsim/thermo/phase/PhaseGERG2008EosTest.java
@@ -1,0 +1,48 @@
+package neqsim.thermo.phase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemGERG2008Eos;
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * Basic property check for {@link PhaseGERG2008Eos} against direct GERG2008 evaluation.
+ */
+class PhaseGERG2008EosTest {
+  @Test
+  void testPhasePropertiesMatchGERG() {
+    SystemInterface system = new SystemGERG2008Eos(298.15, 10.0);
+    system.addComponent("methane", 0.85);
+    system.addComponent("hydrogen", 0.15);
+    system.init(0);
+    system.init(3);
+
+    double[] props = system.getPhase(0).getProperties_GERG2008();
+    double moles = system.getPhase(0).getNumberOfMolesInPhase();
+
+    double enthalpy = system.getPhase(0).getEnthalpy() / moles;
+    assertEquals(props[7], enthalpy, 1e-9);
+
+    double internalEnergy = system.getPhase(0).getInternalEnergy() / moles;
+    assertEquals(props[6], internalEnergy, 1e-9);
+
+    double entropy = system.getPhase(0).getEntropy() / moles;
+    assertEquals(props[8], entropy, 1e-9);
+
+    double cv = system.getPhase(0).getCv() / moles;
+    assertEquals(props[9], cv, 1e-9);
+
+    double cp = system.getPhase(0).getCp() / moles;
+    assertEquals(props[10], cp, 1e-9);
+
+    double soundSpeed = system.getPhase(0).getSoundSpeed();
+    assertEquals(props[11], soundSpeed, 1e-2);
+
+    double jt = system.getPhase(0).getJouleThomsonCoefficient();
+    assertEquals(props[13] * 1e3, jt, 1e-6);
+
+    double density = system.getPhase(0).getDensity();
+    double gergDensity = system.getPhase(0).getDensity_GERG2008();
+    assertEquals(gergDensity, density, 1e-10);
+  }
+}


### PR DESCRIPTION
## Summary
- expose cached ideal and residual Helmholtz derivatives in `PhaseGERG2008Eos`
- implement basic chemical potential derivatives in `ComponentGERG2008Eos`
- validate GERG2008 phase properties including enthalpy, density and additional energy derivatives

## Testing
- `mvn -Dtest=PhaseGERG2008EosTest test`


------
https://chatgpt.com/codex/tasks/task_e_68acd17ddf68832db985d54c879a9962