### PR TITLE
Enable GERG2008 liquid densities and validate bubble point calculations

### DIFF
--- a/src/main/java/neqsim/thermo/util/gerg/NeqSimGERG2008.java
+++ b/src/main/java/neqsim/thermo/util/gerg/NeqSimGERG2008.java
@@ -4,6 +4,7 @@ import org.netlib.util.StringW;
 import org.netlib.util.doubleW;
 import org.netlib.util.intW;
 import neqsim.thermo.phase.PhaseInterface;
+import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
 import neqsim.thermodynamicoperations.ThermodynamicOperations;
@@ -120,6 +121,12 @@ public class NeqSimGERG2008 {
    */
   public double getMolarDensity() {
     int flag = 0;
+    if (phase != null) {
+      PhaseType type = phase.getType();
+      if (type == PhaseType.LIQUID || type == PhaseType.OIL || type == PhaseType.AQUEOUS) {
+        flag = 2; // search for high density root
+      }
+    }
     intW ierr = new intW(0);
     StringW herr = new StringW("");
     doubleW D = new doubleW(0.0);

--- a/src/test/java/neqsim/thermo/util/gerg/GERG2008BubblePointTest.java
+++ b/src/test/java/neqsim/thermo/util/gerg/GERG2008BubblePointTest.java
@@ -1,0 +1,45 @@
+package neqsim.thermo.util.gerg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.netlib.util.StringW;
+import org.netlib.util.doubleW;
+import org.netlib.util.intW;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Check bubble point calculation and verify GERG2008 liquid density at the bubble point.
+ */
+public class GERG2008BubblePointTest {
+  @Test
+  public void testBubblePointPressureAndDensity() throws Exception {
+    SystemSrkEos fluid = new SystemSrkEos();
+    fluid.addComponent("methane", 0.7);
+    fluid.addComponent("ethane", 0.1);
+    fluid.addComponent("propane", 0.1);
+    fluid.addComponent("n-butane", 0.1);
+    fluid.setMixingRule("classic");
+    fluid.setPressure(10.0, "bara");
+    fluid.setTemperature(-50.0, "C");
+
+    ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
+    ops.bubblePointPressureFlash(false);
+
+    assertEquals(65.150271897839, fluid.getPressure(), 1e-6);
+
+    NeqSimGERG2008 gerg = new NeqSimGERG2008(fluid.getPhase(1));
+    double density = gerg.getDensity();
+
+    GERG2008 lib = new GERG2008();
+    lib.SetupGERG();
+    doubleW D = new doubleW(0.0);
+    intW ierr = new intW(0);
+    StringW herr = new StringW("");
+    lib.DensityGERG(2, fluid.getTemperature(), fluid.getPressure() * 100.0,
+        gerg.normalizedGERGComposition, D, ierr, herr);
+    double expected = D.val * fluid.getMolarMass() * 1000.0;
+
+    assertEquals(expected, density, expected * 1e-6);
+  }
+}

--- a/src/test/java/neqsim/thermo/util/gerg/NeqSimGERG2008LiquidDensityTest.java
+++ b/src/test/java/neqsim/thermo/util/gerg/NeqSimGERG2008LiquidDensityTest.java
@@ -1,0 +1,38 @@
+package neqsim.thermo.util.gerg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.netlib.util.StringW;
+import org.netlib.util.doubleW;
+import org.netlib.util.intW;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Verify that GERG2008 density evaluation works for liquid phases.
+ */
+public class NeqSimGERG2008LiquidDensityTest {
+  @Test
+  public void testPureButaneLiquidDensity() throws Exception {
+    double temperature = 298.15; // K
+    double pressure = 10.0; // bar
+    SystemInterface system = new SystemSrkEos(temperature, pressure);
+    system.addComponent("n-butane", 1.0);
+    new ThermodynamicOperations(system).TPflash();
+
+    NeqSimGERG2008 gerg = new NeqSimGERG2008(system.getPhase(0));
+    double density = gerg.getDensity();
+
+    // Reference density from direct GERG2008 call
+    GERG2008 lib = new GERG2008();
+    lib.SetupGERG();
+    doubleW D = new doubleW(0.0);
+    intW ierr = new intW(0);
+    StringW herr = new StringW("");
+    lib.DensityGERG(2, temperature, pressure * 100.0, gerg.normalizedGERGComposition, D, ierr, herr);
+    double expected = D.val * system.getMolarMass() * 1000.0;
+
+    assertEquals(expected, density, expected * 1e-6);
+  }
+}


### PR DESCRIPTION
## Summary
- adjust GERG2008 density routine to search for high-density root when phase is liquid
- add regression tests for liquid GERG2008 densities and bubble point accuracy

## Testing
- `mvn -Dtest=neqsim.thermo.util.gerg.NeqSimGERG2008LiquidDensityTest,neqsim.thermo.util.gerg.GERG2008BubblePointTest test`

------
https://chatgpt.com/codex/tasks/task_e_68acf2427758832d93482fbe80f0755a