### PR TITLE
fix: improve GERG2008 thermodynamic derivatives

### DIFF
--- a/src/main/java/neqsim/thermo/component/ComponentGERG2008Eos.java
+++ b/src/main/java/neqsim/thermo/component/ComponentGERG2008Eos.java
@@ -143,8 +143,7 @@ public class ComponentGERG2008Eos extends ComponentEos {
       double pressure) {
     PhaseGERG2008Eos ph = (PhaseGERG2008Eos) phase;
     double alphar = ph.getAlphaRes() != null ? ph.getAlphaRes()[0][1].val : 0.0;
-    return ThermodynamicConstantsInterface.R * temperature / phase.getVolume()
-        * (1.0 + alphar);
+    return -(1.0 + alphar) / phase.getVolume();
   }
 
   /** {@inheritDoc} */
@@ -166,5 +165,24 @@ public class ComponentGERG2008Eos extends ComponentEos {
         dFdN(phase, phase.getNumberOfComponents(), temperature, pressure) - Math.log(phase.getZ());
     double fugacityCoefficient = Math.exp(logFugacityCoefficient);
     return fugacityCoefficient;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double logfugcoefdP(PhaseInterface phase) {
+    double Z = phase.getZ();
+    double pressure = phase.getPressure();
+    dfugdp = (Z - 1.0) / pressure;
+    return dfugdp;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double logfugcoefdT(PhaseInterface phase) {
+    double hres = phase.getHresTP();
+    double temperature = phase.getTemperature();
+    double n = phase.getNumberOfMolesInPhase();
+    dfugdt = -hres / (n * ThermodynamicConstantsInterface.R * temperature * temperature);
+    return dfugdt;
   }
 }

--- a/src/main/java/neqsim/thermo/phase/PhaseGERG2008Eos.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseGERG2008Eos.java
@@ -205,6 +205,31 @@ public class PhaseGERG2008Eos extends PhaseEos {
 
   /** {@inheritDoc} */
   @Override
+  public double dFdTdV() {
+    // d/dT d/dV (F/RT) = -(1/(R T)) * (dP/dT)_V + P/(R T^2)
+    if (ar == null) {
+      return super.dFdTdV();
+    }
+    double dPdT = getdPdTVn();
+    double p = calcPressure();
+    return -dPdT / (R * temperature) + p / (R * temperature * temperature);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double dFdVdV() {
+    // During early initialisation the Helmholtz derivative array may not yet be
+    // populated.  In that case fall back to the default implementation.
+    if (ar == null) {
+      return super.dFdVdV();
+    }
+    // d^2(F/RT)/dV^2 = -(1/(R T)) * (dP/dV)_T
+    double dPdV = calcPressuredV();
+    return -dPdV / (R * temperature);
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public double getDensity() {
     return getDensity_GERG2008();
   }
@@ -212,7 +237,7 @@ public class PhaseGERG2008Eos extends PhaseEos {
   /** {@inheritDoc} */
   @Override
   public double getdPdTVn() {
-    return (getNumberOfMolesInPhase() / getVolume()) * R * (1 + ar[0][1].val + ar[1][1].val);
+    return (getNumberOfMolesInPhase() / getVolume()) * R * (1 + ar[0][1].val - ar[1][1].val);
   }
 
   /** {@inheritDoc} */
@@ -226,6 +251,22 @@ public class PhaseGERG2008Eos extends PhaseEos {
   @Override
   public double getdPdrho() {
     return R * temperature * (1 + 2 * ar[0][1].val + ar[0][2].val);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getGresTP() {
+    double ar00 = ar != null ? ar[0][0].val : 0.0;
+    double ar01 = ar != null ? ar[0][1].val : 0.0;
+    return numberOfMolesInPhase * R * temperature * (ar00 + ar01);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getHresTP() {
+    double ar10 = ar != null ? ar[1][0].val : 0.0;
+    double ar01 = ar != null ? ar[0][1].val : 0.0;
+    return numberOfMolesInPhase * R * temperature * (ar10 + ar01);
   }
 
   /**

--- a/src/main/java/neqsim/thermo/util/gerg/NeqSimGERG2008.java
+++ b/src/main/java/neqsim/thermo/util/gerg/NeqSimGERG2008.java
@@ -392,9 +392,13 @@ public class NeqSimGERG2008 {
       }
     }
 
-    // Call the GERG2008 function to fill in the ar array.
-    // The first two parameters (itau and idelta) are set to 0.
-    GERG2008.AlpharGERG(0, 0, temperature, molarDensity, normalizedGERGComposition, ar);
+    // Call the GERG2008 function to fill in the ar array. The first two
+    // arguments specify the highest order of \u03c4- and \u03b4-derivatives to
+    // return.  Thermodynamic consistency requires mixed temperature/volume
+    // derivatives as well as up to third-order volume derivatives, so request
+    // \u03c4-derivatives up to second order and \u03b4-derivatives up to third
+    // order.
+    GERG2008.AlpharGERG(2, 3, temperature, molarDensity, normalizedGERGComposition, ar);
 
     // Return the computed dimensionless residual Helmholtz free energy.
     // This is equivalent to alpha_res = A^r/(RT)

--- a/src/test/java/neqsim/thermo/util/gerg/GERG2008ConsistencyTest.java
+++ b/src/test/java/neqsim/thermo/util/gerg/GERG2008ConsistencyTest.java
@@ -1,0 +1,24 @@
+package neqsim.thermo.util.gerg;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.ThermodynamicModelTest;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class GERG2008ConsistencyTest {
+  @Test
+  void testThermodynamicConsistency() {
+    SystemInterface system = new neqsim.thermo.system.SystemGERG2008Eos(298.15, 10.0);
+    system.addComponent("methane", 0.8);
+    system.addComponent("ethane", 0.2);
+    ThermodynamicOperations ops = new ThermodynamicOperations(system);
+    system.init(0);
+    ops.TPflash();
+    system.init(3);
+
+    ThermodynamicModelTest modelTest = new ThermodynamicModelTest(system);
+    assertTrue(modelTest.checkFugacityCoefficientsDP());
+    assertTrue(modelTest.checkFugacityCoefficientsDT());
+  }
+}


### PR DESCRIPTION
## Summary
- correct GERG2008 dP/dT and mixed Helmholtz derivatives
- request higher-order residual derivatives and analytic fugacity responses
- verify GERG2008 satisfies fugacity-coefficient consistency checks

## Testing
- `mvn -Dtest=neqsim.thermo.phase.PhaseGERG2008EosTest test`
- `mvn -Dtest=neqsim.thermo.util.gerg.GERG2008Test test`
- `mvn -Dtest=neqsim.thermo.util.gerg.GERG2008ConsistencyTest test`


------
https://chatgpt.com/codex/tasks/task_e_68acf0193980832d91e2397f3273a319