### PR TITLE
Add compressor capacity envelope check and test

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -72,6 +72,8 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface 
   private boolean useLeachman = false;
   private boolean useVega = false;
   private boolean limitSpeed = false;
+  private boolean includeMinSpeedLimit = true;
+  private boolean includeMaxSpeedLimit = true;
 
   private String pressureUnit = "bara";
   private String polytropicMethod = "detailed";
@@ -1383,6 +1385,99 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface 
   }
 
   /**
+   * Checks whether the specified operating point is inside the compressor map.
+   *
+   * <p>The operating point is considered within the allowable envelope when it is neither in
+   * surge nor stone wall region and the required speed lies between the minimum and maximum speed
+   * curves. This method can be used in optimization routines to impose
+   * capacity constraints on the compressor.</p>
+   *
+   * @param flow volumetric flow rate in m3/hr
+  * @param head polytropic head
+  * @return {@code true} if the operating point is inside the map boundaries
+  */
+  public boolean isWithinOperatingEnvelope(double flow, double head) {
+    return isWithinOperatingEnvelope(flow, head, includeMinSpeedLimit, includeMaxSpeedLimit);
+  }
+
+  /**
+   * Checks whether an operating point lies between surge and stonewall limits and, optionally, the
+   * minimum and/or maximum speed curves. This method can be used in optimization routines to impose
+   * capacity constraints on the compressor.
+   *
+   * @param flow volumetric flow rate in m3/hr
+   * @param head polytropic head
+   * @param includeMinSpeedLimit whether to enforce the minimum speed limit
+   * @param includeMaxSpeedLimit whether to enforce the maximum speed limit
+   * @return {@code true} if the operating point is inside the map boundaries
+   */
+  public boolean isWithinOperatingEnvelope(double flow, double head, boolean includeMinSpeedLimit,
+      boolean includeMaxSpeedLimit) {
+    CompressorChartInterface chart = getCompressorChart();
+    double speed = chart.getSpeed(flow, head);
+    boolean withinSurge = !chart.getSurgeCurve().isSurge(head, flow);
+    boolean withinStoneWall = !chart.getStoneWallCurve().isStoneWall(head, flow);
+    boolean aboveMin = !includeMinSpeedLimit || speed >= chart.getMinSpeedCurve();
+    boolean belowMax = !includeMaxSpeedLimit || speed <= chart.getMaxSpeedCurve();
+    return withinSurge && withinStoneWall && aboveMin && belowMax;
+  }
+
+  /**
+   * Checks whether an operating point lies between surge and stonewall limits and, optionally, the
+   * minimum and maximum speed curves. This overload applies the same inclusion flag to both limits
+   * for backward compatibility.
+   *
+   * @param flow volumetric flow rate in m3/hr
+   * @param head polytropic head
+   * @param includeSpeedLimits whether to enforce minimum and maximum speed limits
+   * @return {@code true} if the operating point is inside the map boundaries
+   */
+  public boolean isWithinOperatingEnvelope(double flow, double head, boolean includeSpeedLimits) {
+    return isWithinOperatingEnvelope(flow, head, includeSpeedLimits, includeSpeedLimits);
+  }
+
+  /**
+   * Convenience overload that evaluates the envelope check for the compressor's current
+   * operating point. Useful for fixed-speed machines where the speed is not varied during the
+   * calculation.
+   *
+   * @return {@code true} if the compressor's present flow and head are inside the map boundaries
+   */
+  public boolean isWithinOperatingEnvelope() {
+    return isWithinOperatingEnvelope(includeMinSpeedLimit, includeMaxSpeedLimit);
+  }
+
+  /**
+   * Convenience overload that evaluates the envelope check for the compressor's current operating
+   * point with optional speed-limit enforcement. Useful for fixed-speed machines where the speed is
+   * not varied during the calculation.
+   *
+   * @param includeMinSpeedLimit whether to enforce the minimum speed limit
+   * @param includeMaxSpeedLimit whether to enforce the maximum speed limit
+   * @return {@code true} if the compressor's present flow and head are inside the map boundaries
+   */
+  public boolean isWithinOperatingEnvelope(boolean includeMinSpeedLimit,
+      boolean includeMaxSpeedLimit) {
+    if (thermoSystem == null) {
+      logger.warn("Thermo system not initialized for compressor {}", getName());
+      return false;
+    }
+    return isWithinOperatingEnvelope(thermoSystem.getFlowRate("m3/hr"), getPolytropicHead(),
+        includeMinSpeedLimit, includeMaxSpeedLimit);
+  }
+
+  /**
+   * Convenience overload that applies the same inclusion flag to both speed limits for backward
+   * compatibility.
+   *
+   * @param includeSpeedLimits whether to enforce minimum and maximum speed limits
+   * @return {@code true} if the compressor's present flow and head are inside the map boundaries
+   */
+  public boolean isWithinOperatingEnvelope(boolean includeSpeedLimits) {
+    return isWithinOperatingEnvelope(includeSpeedLimits, includeSpeedLimits);
+  }
+
+  /**
    * <p>
    * Setter for the field <code>antiSurge</code>.
    * </p>
@@ -1978,5 +2073,45 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface 
    */
   public void setLimitSpeed(boolean limitSpeed) {
     this.limitSpeed = limitSpeed;
+  }
+
+  /**
+   * Checks if the minimum speed limit is enforced when evaluating the operating envelope.
+   *
+   * @return {@code true} if the minimum speed limit is enforced, {@code false} otherwise.
+   */
+  public boolean isIncludeMinSpeedLimit() {
+    return includeMinSpeedLimit;
+  }
+
+  /**
+   * Sets whether the minimum speed limit should be enforced when evaluating the operating
+   * envelope.
+   *
+   * @param includeMinSpeedLimit {@code true} to enforce the minimum speed limit, {@code false} to
+   *        ignore it
+   */
+  public void setIncludeMinSpeedLimit(boolean includeMinSpeedLimit) {
+    this.includeMinSpeedLimit = includeMinSpeedLimit;
+  }
+
+  /**
+   * Checks if the maximum speed limit is enforced when evaluating the operating envelope.
+   *
+   * @return {@code true} if the maximum speed limit is enforced, {@code false} otherwise.
+   */
+  public boolean isIncludeMaxSpeedLimit() {
+    return includeMaxSpeedLimit;
+  }
+
+  /**
+   * Sets whether the maximum speed limit should be enforced when evaluating the operating
+   * envelope.
+   *
+   * @param includeMaxSpeedLimit {@code true} to enforce the maximum speed limit, {@code false} to
+   *        ignore it
+   */
+  public void setIncludeMaxSpeedLimit(boolean includeMaxSpeedLimit) {
+    this.includeMaxSpeedLimit = includeMaxSpeedLimit;
   }
 }

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorChart.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorChart.java
@@ -574,6 +574,7 @@ public class CompressorChart implements CompressorChartInterface, java.io.Serial
    *
    * @return a double
    */
+  @Override
   public double getMaxSpeedCurve() {
     return maxSpeedCurve;
   }

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorChartAlternativeMapLookup.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorChartAlternativeMapLookup.java
@@ -708,7 +708,24 @@ public class CompressorChartAlternativeMapLookup extends CompressorChart
   /** {@inheritDoc} */
   @Override
   public double getMinSpeedCurve() {
-    return 0;
+    double min = Double.MAX_VALUE;
+    for (CompressorCurve curve : chartValues) {
+      if (curve.speed < min) {
+        min = curve.speed;
+      }
+    }
+    return min == Double.MAX_VALUE ? 0.0 : min;
+  }
+
+  @Override
+  public double getMaxSpeedCurve() {
+    double max = 0.0;
+    for (CompressorCurve curve : chartValues) {
+      if (curve.speed > max) {
+        max = curve.speed;
+      }
+    }
+    return max;
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorChartInterface.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorChartInterface.java
@@ -207,9 +207,18 @@ public interface CompressorChartInterface extends Cloneable {
    * Getter for the field <code>minSpeedCurve</code>.
    * </p>
    *
+  * @return a double
+  */
+  public double getMinSpeedCurve();
+
+  /**
+   * <p>
+   * Getter for the field <code>maxSpeedCurve</code>.
+   * </p>
+   *
    * @return a double
    */
-  public double getMinSpeedCurve();
+  public double getMaxSpeedCurve();
 
   public void generateSurgeCurve();
 

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorCapacityCheckTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorCapacityCheckTest.java
@@ -1,0 +1,85 @@
+package neqsim.process.equipment.compressor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+public class CompressorCapacityCheckTest {
+
+  @Test
+  public void testOperatingEnvelopeSingleSpeed() {
+    SystemInterface gas = new SystemSrkEos(298.15, 50.0);
+    gas.addComponent("methane", 100.0);
+    gas.setMixingRule(2);
+    Stream inlet = new Stream("inlet", gas);
+    Compressor comp = new Compressor("comp", inlet);
+
+    CompressorChart chart = new CompressorChart();
+    double[] chartConditions = new double[] {0.3, 1.0, 1.0, 1.0};
+    double[] speed = new double[] {1000.0};
+    double[][] flow = new double[][] {{1000.0, 1500.0, 2000.0, 2500.0}};
+    double[][] head = new double[][] {{80.0, 70.0, 60.0, 50.0}};
+    double[][] eff = new double[][] {{80.0, 80.0, 80.0, 80.0}};
+    chart.setCurves(chartConditions, speed, flow, head, eff);
+    double[] surgeFlow = new double[] {900.0, 1200.0, 1500.0, 1800.0};
+    double[] surgeHead = new double[] {85.0, 75.0, 65.0, 55.0};
+    chart.getSurgeCurve().setCurve(chartConditions, surgeFlow, surgeHead);
+    double[] stoneFlow = new double[] {2500.0, 2600.0, 2700.0, 2800.0};
+    double[] stoneHead = new double[] {80.0, 70.0, 60.0, 50.0};
+    chart.getStoneWallCurve().setCurve(chartConditions, stoneFlow, stoneHead);
+    comp.setCompressorChart(chart);
+
+    double headInside = chart.getPolytropicHead(1700.0, 1000.0);
+    assertTrue(comp.isWithinOperatingEnvelope(1700.0, headInside));
+    assertFalse(comp.isWithinOperatingEnvelope(1100.0, 70.0));
+    assertFalse(comp.isWithinOperatingEnvelope(3000.0, 60.0));
+  }
+
+  @Test
+  public void testOperatingEnvelopeSpeedLimits() {
+    SystemInterface gas = new SystemSrkEos(298.15, 50.0);
+    gas.addComponent("methane", 100.0);
+    gas.setMixingRule(2);
+    Stream inlet = new Stream("inlet", gas);
+    Compressor comp = new Compressor("comp", inlet);
+
+    CompressorChart chart = new CompressorChart();
+    double[] chartConditions = new double[] {0.3, 1.0, 1.0, 1.0};
+    double[] speed = new double[] {1000.0, 2000.0};
+    double[][] flow = new double[][] {{1000.0, 1500.0, 2000.0}, {1000.0, 1500.0, 2000.0}};
+    double[][] head = new double[][] {{80.0, 70.0, 60.0}, {320.0, 280.0, 240.0}};
+    double[][] eff = new double[][] {{80.0, 80.0, 80.0}, {80.0, 80.0, 80.0}};
+    chart.setCurves(chartConditions, speed, flow, head, eff);
+    double[] surgeFlow = new double[] {0.0, 1.0, 2.0, 3.0};
+    double[] surgeHead = new double[] {0.0, 10.0, 20.0, 30.0};
+    chart.getSurgeCurve().setCurve(chartConditions, surgeFlow, surgeHead);
+    double[] stoneFlow = new double[] {10000.0, 10001.0, 10002.0, 10003.0};
+    double[] stoneHead = new double[] {0.0, 10.0, 20.0, 30.0};
+    chart.getStoneWallCurve().setCurve(chartConditions, stoneFlow, stoneHead);
+    comp.setCompressorChart(chart);
+
+    double headMid = chart.getPolytropicHead(1500.0, 1500.0);
+    assertTrue(comp.isWithinOperatingEnvelope(1500.0, headMid));
+
+    double headBelow = chart.getPolytropicHead(1500.0, 500.0);
+    assertFalse(comp.isWithinOperatingEnvelope(1500.0, headBelow));
+    assertTrue(comp.isWithinOperatingEnvelope(1500.0, headBelow, false, true));
+    assertTrue(comp.isWithinOperatingEnvelope(1500.0, headBelow, false));
+    comp.setIncludeMinSpeedLimit(false);
+    assertFalse(comp.isIncludeMinSpeedLimit());
+    assertTrue(comp.isWithinOperatingEnvelope(1500.0, headBelow));
+    comp.setIncludeMinSpeedLimit(true);
+
+    double headAbove = chart.getPolytropicHead(1500.0, 2500.0);
+    assertFalse(comp.isWithinOperatingEnvelope(1500.0, headAbove));
+    assertTrue(comp.isWithinOperatingEnvelope(1500.0, headAbove, true, false));
+    assertTrue(comp.isWithinOperatingEnvelope(1500.0, headAbove, false));
+    comp.setIncludeMaxSpeedLimit(false);
+    assertFalse(comp.isIncludeMaxSpeedLimit());
+    assertTrue(comp.isWithinOperatingEnvelope(1500.0, headAbove));
+  }
+}


### PR DESCRIPTION
## Summary
- allow compressor envelope check to enforce minimum and maximum speed limits independently
- expose configuration getters/setters to enable or ignore low/high speed limits
- add unit tests exercising separate min and max speed limit toggles and field-based configuration

## Testing
- `mvn -Dtest=CompressorCapacityCheckTest test`


------
https://chatgpt.com/codex/tasks/task_e_68ad54b599f8832da850a47b3ed40662