### PR TITLE
feat: add option to toggle compressor efficiency curves

### DIFF
--- a/src/test/java/neqsim/process/equipment/compressor/CompressorCalculationTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorCalculationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermo.ThermodynamicConstantsInterface;
 
 public class CompressorCalculationTest extends neqsim.NeqSimTest {
   Compressor comp1;
@@ -95,6 +96,7 @@ public class CompressorCalculationTest extends neqsim.NeqSimTest {
   public void testRun() {
     setCurves();
     comp1.setUsePolytropicCalc(true);
+    comp1.setUseEfficiencyCurve(true);
     comp1.setSpeed(11918);
     neqsim.process.processmodel.ProcessSystem operations =
         new neqsim.process.processmodel.ProcessSystem();
@@ -127,5 +129,92 @@ public class CompressorCalculationTest extends neqsim.NeqSimTest {
      * comp1.getPolytropicEfficiency()); logger.info("temperature out " + (comp1.getOutTemperature()
      * - 273.15) + " C"); logger.info("calculated speed " + calcSpeed);
      */
+  }
+
+  @Test
+  public void testHeadFromFixedOutletPressure() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule(2);
+    Stream stream = new Stream("stream", fluid);
+    stream.setPressure(10.0, "bara");
+    stream.setTemperature(25.0, "C");
+    stream.setFlowRate(1000.0, "Am3/hr");
+
+    Compressor compressor = new Compressor("comp", stream);
+    double[] chartConditions = new double[] {0.3, 1.0, 1.0, 1.0};
+    double[] speed = new double[] {1000.0};
+    double[][] flow = new double[][] {{800.0, 1200.0}};
+    double[][] head = new double[][] {{50.0, 60.0}};
+    double[][] polyEff = new double[][] {{80.0, 80.0}};
+    compressor.getCompressorChart().setCurves(chartConditions, speed, flow, head, polyEff);
+    compressor.getCompressorChart().setHeadUnit("kJ/kg");
+    compressor.setUsePolytropicCalc(true);
+    compressor.setUseEfficiencyCurve(true);
+    compressor.setSpeed(500.0);
+    double targetPressure = 20.0;
+    compressor.setOutletPressure(targetPressure);
+
+    stream.run();
+    double z = stream.getThermoSystem().getZ();
+    double MW = stream.getThermoSystem().getMolarMass();
+    double temperature = stream.getThermoSystem().getTemperature();
+    double kappa = stream.getThermoSystem().getGamma2();
+    double eff = 0.80;
+    double n = 1.0 / (1.0 - (kappa - 1.0) / kappa / eff);
+    double pressureRatio = targetPressure / stream.getThermoSystem().getPressure();
+    double expectedHead =
+        n / (n - 1.0) * z * ThermodynamicConstantsInterface.R * temperature / MW
+            * (Math.pow(pressureRatio, (n - 1.0) / n) - 1.0);
+    double expectedSpeed = compressor.getCompressorChart().getSpeed(
+        stream.getThermoSystem().getFlowRate("m3/hr"), expectedHead);
+
+    neqsim.process.processmodel.ProcessSystem operations =
+        new neqsim.process.processmodel.ProcessSystem();
+    operations.add(stream);
+    operations.add(compressor);
+    operations.run();
+
+    Assertions.assertEquals(eff, compressor.getPolytropicEfficiency(), 1e-6);
+    Assertions.assertEquals(expectedHead, compressor.getPolytropicHead(), 1e-4);
+    Assertions.assertEquals(targetPressure, compressor.getOutletPressure(), 1e-6);
+    Assertions.assertEquals(expectedSpeed, compressor.getSpeed(), 1e-6);
+  }
+
+  @Test
+  public void testEfficiencyCurveToggle() {
+    SystemInterface fluid = new SystemSrkEos(298.15, 10.0);
+    fluid.addComponent("methane", 1.0);
+    fluid.setMixingRule(2);
+    Stream stream = new Stream("stream", fluid);
+    stream.setPressure(10.0, "bara");
+    stream.setTemperature(25.0, "C");
+    stream.setFlowRate(1000.0, "Am3/hr");
+
+    Compressor compressor = new Compressor("comp", stream);
+    double[] chartConditions = new double[] {0.3, 1.0, 1.0, 1.0};
+    double[] speed = new double[] {1000.0};
+    double[][] flow = new double[][] {{800.0, 1200.0}};
+    double[][] head = new double[][] {{50.0, 60.0}};
+    double[][] polyEff = new double[][] {{80.0, 90.0}};
+    compressor.getCompressorChart().setCurves(chartConditions, speed, flow, head, polyEff);
+    compressor.getCompressorChart().setHeadUnit("kJ/kg");
+    compressor.setUsePolytropicCalc(true);
+    compressor.setPolytropicEfficiency(0.7);
+    compressor.setOutletPressure(20.0);
+
+    neqsim.process.processmodel.ProcessSystem operations =
+        new neqsim.process.processmodel.ProcessSystem();
+    operations.add(stream);
+    operations.add(compressor);
+    operations.run();
+
+    Assertions.assertEquals(0.7, compressor.getPolytropicEfficiency(), 1e-6);
+
+    compressor.setUseEfficiencyCurve(true);
+    operations.run();
+    double expectedEff = compressor.getCompressorChart().getPolytropicEfficiency(
+        stream.getThermoSystem().getFlowRate("m3/hr"), compressor.getSpeed()) / 100.0;
+    Assertions.assertEquals(expectedEff, compressor.getPolytropicEfficiency(), 1e-6);
   }
 }

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorChartKhader2015Test.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorChartKhader2015Test.java
@@ -32,6 +32,7 @@ public class CompressorChartKhader2015Test {
     stream_1.run();
     Compressor comp1 = new Compressor("cmp1", stream_1);
     comp1.setUsePolytropicCalc(true);
+    comp1.setUseEfficiencyCurve(true);
     double compspeed = 10000;
     comp1.setSpeed(compspeed);
 
@@ -286,6 +287,7 @@ public class CompressorChartKhader2015Test {
     stream_1.run();
     Compressor comp1 = new Compressor("cmp1", stream_1);
     comp1.setUsePolytropicCalc(true);
+    comp1.setUseEfficiencyCurve(true);
     double compspeed = 10000;
     comp1.setSpeed(compspeed);
 

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorChartReaderTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorChartReaderTest.java
@@ -39,6 +39,7 @@ public class CompressorChartReaderTest {
     Compressor compressor = new Compressor("compressor1", stream);
     compressor.setCompressorChartType("interpolate and extrapolate");
     compressor.setUsePolytropicCalc(true);
+    compressor.setUseEfficiencyCurve(true);
     // compressor.setMaximumSpeed(7383);
     // compressor.setMinimumSpeed(4922);
     compressor.setSpeed(3000);

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorChartTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorChartTest.java
@@ -209,6 +209,7 @@ public class CompressorChartTest {
     Compressor comp1 = new Compressor("compressor 1", stream_1);
     comp1.setCompressorChartType("interpolate and extrapolate");
     comp1.setUsePolytropicCalc(true);
+    comp1.setUseEfficiencyCurve(true);
     comp1.setSpeed(8765);
     comp1.setUseGERG2008(false);
 
@@ -301,6 +302,7 @@ public class CompressorChartTest {
     Compressor comp1 = new Compressor("compressor 1", stream_1);
     comp1.setCompressorChartType("interpolate and extrapolate");
     comp1.setUsePolytropicCalc(true);
+    comp1.setUseEfficiencyCurve(true);
     comp1.setPolytropicEfficiency(0.85);
     comp1.setSpeed(9000);
     double[] chartConditions = new double[] {0.3, 1.0, 1.0, 1.0};
@@ -406,6 +408,7 @@ public class CompressorChartTest {
     Compressor comp1 = new Compressor("compressor 1", stream_1);
     // comp1.setCompressorChartType("interpolate and extrapolate");
     comp1.setUsePolytropicCalc(true);
+    comp1.setUseEfficiencyCurve(true);
     comp1.setPolytropicEfficiency(0.85);
     comp1.setSpeed(9000);
     double[] chartConditions = new double[] {0.3, 1.0, 1.0, 1.0};


### PR DESCRIPTION
## Summary
- add `setUseEfficiencyCurve` toggle to optionally pull efficiency from compressor charts
- update compressor speed and head calculations to honor toggle
- expand tests to cover using or bypassing efficiency curves

## Testing
- `mvn -e -Dtest=CompressorTest,CompressorChartTest,CompressorCalculationTest,CompressorChartReaderTest,CompressorChartKhader2015Test test`

------
https://chatgpt.com/codex/tasks/task_e_68ad5dc67230832db04b5db926b6504a