### PR TITLE
Add mechanical design for heat exchangers, compressors, and valves

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -73,6 +73,8 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface 
   private boolean useVega = false;
   private boolean limitSpeed = false;
 
+  CompressorMechanicalDesign mechanicalDesign;
+
   private String pressureUnit = "bara";
   private String polytropicMethod = "detailed";
 
@@ -83,6 +85,7 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface 
    */
   public Compressor(String name) {
     super(name);
+    initMechanicalDesign();
   }
 
   /**
@@ -116,7 +119,13 @@ public class Compressor extends TwoPortEquipment implements CompressorInterface 
   /** {@inheritDoc} */
   @Override
   public CompressorMechanicalDesign getMechanicalDesign() {
-    return new CompressorMechanicalDesign(this);
+    return mechanicalDesign;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void initMechanicalDesign() {
+    mechanicalDesign = new CompressorMechanicalDesign(this);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/heatexchanger/HeatExchanger.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/HeatExchanger.java
@@ -12,6 +12,7 @@ import neqsim.process.conditionmonitor.ConditionMonitorSpecifications;
 import neqsim.process.equipment.ProcessEquipmentInterface;
 import neqsim.process.equipment.stream.Stream;
 import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.mechanicaldesign.heatexchanger.HeatExchangerMechanicalDesign;
 import neqsim.process.util.monitor.HXResponse;
 import neqsim.process.util.report.ReportConfig;
 import neqsim.process.util.report.ReportConfig.DetailLevel;
@@ -52,6 +53,8 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface {
   private String flowArrangement = "concentric tube counterflow";
   private boolean useDeltaT = false;
   private double deltaT = 1.0;
+
+  HeatExchangerMechanicalDesign mechanicalDesign;
 
   /**
    * Constructor for HeatExchanger.
@@ -113,6 +116,18 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface {
     this.inStream[number] = inStream;
     outStream[number] = inStream.clone();
     setName(getName());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public HeatExchangerMechanicalDesign getMechanicalDesign() {
+    return mechanicalDesign;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void initMechanicalDesign() {
+    mechanicalDesign = new HeatExchangerMechanicalDesign(this);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -78,7 +78,6 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface 
   public ThrottlingValve(String name, StreamInterface inletStream) {
     this(name);
     setInletStream(inletStream);
-    valveMechanicalDesign = new ValveMechanicalDesign(this);
   }
 
   /**

--- a/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/compressor/CompressorMechanicalDesign.java
@@ -165,6 +165,9 @@ public class CompressorMechanicalDesign extends MechanicalDesign {
       innerDiameter = Daim;
       tantanLength = Length2;
     }
+    if (getWallThickness() <= 0.0) {
+      setWallThickness(0.01);
+    }
     // calculating from standard codes
     // sepLength = innerDiameter * 2.0;
     emptyVesselWeight = 0.032 * getWallThickness() * 1e3 * innerDiameter * 1e3 * tantanLength;

--- a/src/main/java/neqsim/process/mechanicaldesign/heatexchanger/HeatExchangerMechanicalDesign.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/heatexchanger/HeatExchangerMechanicalDesign.java
@@ -1,0 +1,59 @@
+package neqsim.process.mechanicaldesign.heatexchanger;
+
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.heatexchanger.HeatExchanger;
+import neqsim.process.mechanicaldesign.MechanicalDesign;
+
+/**
+ * Mechanical design for a generic heat exchanger. Provides rough estimates of size
+ * and weight based on duty and assumed overall heat-transfer coefficients.
+ */
+public class HeatExchangerMechanicalDesign extends MechanicalDesign {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1000;
+
+  /**
+   * Constructor for HeatExchangerMechanicalDesign.
+   *
+   * @param equipment {@link neqsim.process.equipment.ProcessEquipmentInterface} object
+   */
+  public HeatExchangerMechanicalDesign(ProcessEquipmentInterface equipment) {
+    super(equipment);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void calcDesign() {
+    super.calcDesign();
+    HeatExchanger exchanger = (HeatExchanger) getProcessEquipment();
+
+    double U = 500.0; // W/(m^2*K)
+    double area = exchanger.getUAvalue() / U;
+    if (area <= 0.0) {
+      double duty = Math.abs(exchanger.getDuty());
+      double deltaT =
+          Math.abs(exchanger.getOutTemperature(0) - exchanger.getOutTemperature(1));
+      if (deltaT > 0.0) {
+        area = duty / (U * deltaT);
+      }
+    }
+    if (area <= 0.0) {
+      area = 1.0;
+    }
+
+    innerDiameter = Math.sqrt(area / (2.0 * Math.PI));
+    tantanLength = 2.0 * innerDiameter;
+    wallThickness = 0.01; // 10 mm
+    outerDiameter = innerDiameter + 2.0 * wallThickness;
+
+    double shellArea = Math.PI * innerDiameter * tantanLength;
+    double steelDensity = 7850.0; // kg/m3
+    weightVessel = shellArea * wallThickness * steelDensity;
+    setWeigthVesselShell(weightVessel);
+    setWeightTotal(weightVessel);
+    setModuleLength(tantanLength + 1.0);
+    setModuleWidth(innerDiameter + 1.0);
+    setModuleHeight(innerDiameter + 1.0);
+  }
+}
+

--- a/src/main/java/neqsim/process/mechanicaldesign/valve/ControlValveSizing.java
+++ b/src/main/java/neqsim/process/mechanicaldesign/valve/ControlValveSizing.java
@@ -125,8 +125,11 @@ public class ControlValveSizing implements ControlValveSizingInterface, Serializ
     }
 
 
-    return ((ThrottlingValve) valveMechanicalDesign.getProcessEquipment()).getInletStream()
-        .getFlowRate("m3/hr")
+    double massFlow =
+        ((ThrottlingValve) valveMechanicalDesign.getProcessEquipment()).getInletStream()
+            .getFlowRate("kg/hr");
+    double volumetricFlow = massFlow / density;
+    return volumetricFlow
         / Math.sqrt((((ThrottlingValve) valveMechanicalDesign.getProcessEquipment())
             .getInletStream().getPressure("bara")
             - ((ThrottlingValve) valveMechanicalDesign.getProcessEquipment()).getOutletStream()

--- a/src/test/java/neqsim/process/mechanicaldesign/compressor/CompressorMechanicalDesignTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/compressor/CompressorMechanicalDesignTest.java
@@ -1,0 +1,37 @@
+package neqsim.process.mechanicaldesign.compressor;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.compressor.Compressor;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/** Tests for compressor mechanical design calculations. */
+public class CompressorMechanicalDesignTest {
+  @Test
+  void testCalcDesign() {
+    SystemInterface gas = new SystemSrkEos(300.0, 10.0);
+    gas.addComponent("methane", 1.0);
+    gas.setMixingRule(2);
+    ThermodynamicOperations ops = new ThermodynamicOperations(gas);
+    ops.TPflash();
+
+    Stream inlet = new Stream("inlet", gas);
+    inlet.setFlowRate(10.0, "kg/hr");
+
+    Compressor comp = new Compressor("comp", inlet);
+    comp.setOutletPressure(20.0);
+
+    ProcessSystem ps = new ProcessSystem();
+    ps.add(inlet);
+    ps.add(comp);
+    ps.run();
+
+    comp.initMechanicalDesign();
+    comp.getMechanicalDesign().calcDesign();
+    assertTrue(comp.getMechanicalDesign().getWeightTotal() > 0.0);
+  }
+}

--- a/src/test/java/neqsim/process/mechanicaldesign/heatexchanger/HeatExchangerMechanicalDesignTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/heatexchanger/HeatExchangerMechanicalDesignTest.java
@@ -1,0 +1,49 @@
+package neqsim.process.mechanicaldesign.heatexchanger;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.heatexchanger.HeatExchanger;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Tests for HeatExchanger mechanical design calculations.
+ */
+public class HeatExchangerMechanicalDesignTest {
+  @Test
+  void testCalcDesign() {
+    SystemInterface system1 = new SystemSrkEos(273.15 + 60.0, 20.0);
+    system1.addComponent("methane", 120.0);
+    system1.addComponent("ethane", 120.0);
+    system1.addComponent("n-heptane", 3.0);
+    system1.createDatabase(true);
+    system1.setMixingRule(2);
+    ThermodynamicOperations ops1 = new ThermodynamicOperations(system1);
+    ops1.TPflash();
+
+    Stream hot = new Stream("hot", system1);
+    hot.setTemperature(100.0, "C");
+    hot.setFlowRate(1000.0, "kg/hr");
+
+    Stream cold = new Stream("cold", system1.clone());
+    cold.setTemperature(20.0, "C");
+    cold.setFlowRate(310.0, "kg/hr");
+
+    HeatExchanger hx = new HeatExchanger("hx", hot, cold);
+    hx.setUAvalue(1000.0);
+
+    ProcessSystem ps = new ProcessSystem();
+    ps.add(hot);
+    ps.add(cold);
+    ps.add(hx);
+    ps.run();
+
+    hx.initMechanicalDesign();
+    hx.getMechanicalDesign().calcDesign();
+    assertTrue(hx.getMechanicalDesign().getWeightTotal() > 0.0);
+  }
+}
+

--- a/src/test/java/neqsim/process/mechanicaldesign/valve/ValveMechanicalDesignTest.java
+++ b/src/test/java/neqsim/process/mechanicaldesign/valve/ValveMechanicalDesignTest.java
@@ -1,0 +1,37 @@
+package neqsim.process.mechanicaldesign.valve;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests for valve mechanical design calculations. */
+public class ValveMechanicalDesignTest {
+  @Test
+  void testCalcDesign() {
+    SystemInterface gas = new SystemSrkEos(300.0, 10.0);
+    gas.addComponent("methane", 1.0);
+    gas.setMixingRule(2);
+    ThermodynamicOperations ops = new ThermodynamicOperations(gas);
+    ops.TPflash();
+
+    Stream inlet = new Stream("inlet", gas);
+    inlet.setFlowRate(10.0, "kg/hr");
+
+    ThrottlingValve valve = new ThrottlingValve("valve", inlet);
+    valve.setOutletPressure(5.0);
+
+    ProcessSystem ps = new ProcessSystem();
+    ps.add(inlet);
+    ps.add(valve);
+    ps.run();
+
+    valve.initMechanicalDesign();
+    valve.getMechanicalDesign().calcDesign();
+    assertTrue(valve.getMechanicalDesign().getWeightTotal() > 0.0);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `HeatExchangerMechanicalDesign` to estimate size and weight based on duty
- enable mechanical design in `HeatExchanger`
- add unit test for heat exchanger mechanical design
- retain and initialize mechanical design for compressors
- compute valve sizing from mass flow and add valve mechanical design test

## Testing
- `mvn -e -Dtest=CompressorMechanicalDesignTest,ValveMechanicalDesignTest test`
- `mvn -q test` *(fails: PhaseSrkEos:init - Input totalNumberOfMoles must be larger than or equal to zero in ProcessSystemRunTransientTest)*

------
https://chatgpt.com/codex/tasks/task_e_68b2986da294832da4a13e470a6c5ae2