### PR TITLE
Refine supercritical checks for saturation operations

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/BubblePointPressureFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/BubblePointPressureFlash.java
@@ -33,8 +33,8 @@ public class BubblePointPressureFlash extends ConstantDutyPressureFlash {
   @Override
   public void run() {
     if (system.getPhase(0).getNumberOfComponents() == 1
-        && system.getTemperature() > system.getPhase(0).getComponent(0).getTC()) {
-      setSuperCritical(true);
+        && system.getTemperature() >= system.getPhase(0).getComponent(0).getTC()) {
+      throw new IllegalStateException("System is supercritical");
     }
 
     int iterations = 0;
@@ -172,6 +172,9 @@ public class BubblePointPressureFlash extends ConstantDutyPressureFlash {
         || ktot < 1e-3 && system.getPhase(0).getNumberOfComponents() > 1) {
       logger.info("ytot " + Math.abs(ytotal - 1.0));
       setSuperCritical(true);
+    }
+    if (isSuperCritical()) {
+      throw new IllegalStateException("System is supercritical");
     }
   }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/BubblePointPressureFlashDer.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/BubblePointPressureFlashDer.java
@@ -33,8 +33,8 @@ public class BubblePointPressureFlashDer extends ConstantDutyPressureFlash {
   @Override
   public void run() {
     if (system.getPhase(0).getNumberOfComponents() == 1
-        && system.getTemperature() > system.getPhase(0).getComponent(0).getTC()) {
-      setSuperCritical(true);
+        && system.getTemperature() >= system.getPhase(0).getComponent(0).getTC()) {
+      throw new IllegalStateException("System is supercritical");
     }
     int iterations = 0;
     int maxNumberOfIterations = 500;
@@ -190,6 +190,9 @@ public class BubblePointPressureFlashDer extends ConstantDutyPressureFlash {
       // Print command added by Neeraj
       logger.info("Supercritical vapor phase !!");
       setSuperCritical(true);
+    }
+    if (isSuperCritical()) {
+      throw new IllegalStateException("System is supercritical");
     }
   }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/BubblePointTemperatureNoDer.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/BubblePointTemperatureNoDer.java
@@ -33,8 +33,8 @@ public class BubblePointTemperatureNoDer extends ConstantDutyTemperatureFlash {
   @Override
   public void run() {
     if (system.getPhase(0).getNumberOfComponents() == 1
-        && system.getPressure() > system.getPhase(0).getComponent(0).getPC()) {
-      setSuperCritical(true);
+        && system.getPressure() >= system.getPhase(0).getComponent(0).getPC()) {
+      throw new IllegalStateException("System is supercritical");
     }
 
     int iterations = 0;
@@ -46,20 +46,10 @@ public class BubblePointTemperatureNoDer extends ConstantDutyTemperatureFlash {
     system.setBeta(1, 1.0 - 1e-10);
     system.setBeta(0, 1e-10);
     // need to fix this close to critical point
-    if (system.getPhase(0).getNumberOfComponents() == 1) {
-      double oldTemp = system.getTemperature();
-      if (system.getPressure() > system.getPhase(0).getComponent(0).getPC()) {
-        setSuperCritical(true);
-        return;
-      }
-      if (system.getPressure() < system.getPhase(0).getComponent(0).getPC()) {
-        system.setTemperature(
-            system.getPhase(0).getComponent(0).getAntoineVaporTemperature(system.getPressure()));
-      }
-      if (system.getTemperature() > system.getPhase(0).getComponent(0).getTC() || system
-          .getTemperature() < system.getPhase(0).getComponent(0).getTriplePointTemperature()) {
-        system.setTemperature(oldTemp);
-      }
+    if (system.getPhase(0).getNumberOfComponents() == 1
+        && system.getPressure() < system.getPhase(0).getComponent(0).getPC()) {
+      system.setTemperature(
+          system.getPhase(0).getComponent(0).getAntoineVaporTemperature(system.getPressure()));
     }
 
     if (system.isChemicalSystem()) {
@@ -150,6 +140,9 @@ public class BubblePointTemperatureNoDer extends ConstantDutyTemperatureFlash {
         && Math.abs(system.getPhases()[1].getComponent(0).getFugacityCoefficient()
             / system.getPhases()[0].getComponent(0).getFugacityCoefficient() - 1.0) < 1e-20) {
       setSuperCritical(true);
+    }
+    if (isSuperCritical()) {
+      throw new IllegalStateException("System is supercritical");
     }
   }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/ConstantDutyPressureFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/ConstantDutyPressureFlash.java
@@ -28,6 +28,10 @@ public class ConstantDutyPressureFlash extends ConstantDutyFlash {
   /** {@inheritDoc} */
   @Override
   public void run() {
+    if (system.getPhase(0).getNumberOfComponents() == 1
+        && system.getTemperature() >= system.getPhase(0).getComponent(0).getTC()) {
+      throw new IllegalStateException("System is supercritical");
+    }
     // system.calc_x_y();
     // system.init(2);
 
@@ -80,6 +84,9 @@ public class ConstantDutyPressureFlash extends ConstantDutyFlash {
       system.setPressure(pres);
     } while ((Math.abs((system.getPressure() - Pold) / system.getPressure()) > 1e-10
         && iterations < 300) || iterations < 3);
+    if (isSuperCritical()) {
+      throw new IllegalStateException("System is supercritical");
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/DewPointPressureFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/DewPointPressureFlash.java
@@ -29,8 +29,8 @@ public class DewPointPressureFlash extends ConstantDutyTemperatureFlash {
   @Override
   public void run() {
     if (system.getPhase(0).getNumberOfComponents() == 1
-        && system.getPressure() > system.getPhase(0).getComponent(0).getPC()) {
-      setSuperCritical(true);
+        && system.getTemperature() >= system.getPhase(0).getComponent(0).getTC()) {
+      throw new IllegalStateException("System is supercritical");
     }
 
     int iterations = 0;
@@ -106,6 +106,9 @@ public class DewPointPressureFlash extends ConstantDutyTemperatureFlash {
     if (Math.abs(xtotal - 1.0) >= 1e-5
         || ktot < 1e-3 && system.getPhase(0).getNumberOfComponents() > 1) {
       setSuperCritical(true);
+    }
+    if (isSuperCritical()) {
+      throw new IllegalStateException("System is supercritical");
     }
   }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/DewPointTemperatureFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/DewPointTemperatureFlash.java
@@ -29,8 +29,8 @@ public class DewPointTemperatureFlash extends ConstantDutyTemperatureFlash {
   @Override
   public void run() {
     if (system.getPhase(0).getNumberOfComponents() == 1
-        && system.getPressure() > system.getPhase(0).getComponent(0).getPC()) {
-      setSuperCritical(true);
+        && system.getPressure() >= system.getPhase(0).getComponent(0).getPC()) {
+      throw new IllegalStateException("System is supercritical");
     }
 
     int iterations = 0;
@@ -133,13 +133,10 @@ public class DewPointTemperatureFlash extends ConstantDutyTemperatureFlash {
       setSuperCritical(true);
     }
     if (ktot < 1.0e-3) {
-      if (system.getTemperature() < 90.0) {
-        setSuperCritical(true);
-      } else {
-        setSuperCritical(false);
-        // system.setTemperature(system.getTemperature() - 10.0);
-        // run();
-      }
+      setSuperCritical(true);
+    }
+    if (isSuperCritical()) {
+      throw new IllegalStateException("System is supercritical");
     }
   }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/DewPointTemperatureFlashDer.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/DewPointTemperatureFlashDer.java
@@ -29,8 +29,8 @@ public class DewPointTemperatureFlashDer extends ConstantDutyTemperatureFlash {
   @Override
   public void run() {
     if (system.getPhase(0).getNumberOfComponents() == 1
-        && system.getPressure() > system.getPhase(0).getComponent(0).getPC()) {
-      setSuperCritical(true);
+        && system.getPressure() >= system.getPhase(0).getComponent(0).getPC()) {
+      throw new IllegalStateException("System is supercritical");
     }
 
     // System.out.println("starting");
@@ -143,13 +143,10 @@ public class DewPointTemperatureFlashDer extends ConstantDutyTemperatureFlash {
       setSuperCritical(true);
     }
     if (ktot < 1.0e-3) {
-      if (system.getTemperature() < 90.0) {
-        setSuperCritical(true);
-      } else {
-        setSuperCritical(false);
-        // system.setTemperature(system.getTemperature() - 10.0);
-        // run();
-      }
+      setSuperCritical(true);
+    }
+    if (isSuperCritical()) {
+      throw new IllegalStateException("System is supercritical");
     }
   }
 

--- a/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/HCdewPointPressureFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/saturationops/HCdewPointPressureFlash.java
@@ -33,8 +33,8 @@ public class HCdewPointPressureFlash extends ConstantDutyTemperatureFlash {
   @Override
   public void run() {
     if (system.getPhase(0).getNumberOfComponents() == 1
-        && system.getPressure() > system.getPhase(0).getComponent(0).getPC()) {
-      setSuperCritical(true);
+        && system.getTemperature() >= system.getPhase(0).getComponent(0).getTC()) {
+      throw new IllegalStateException("System is supercritical");
     }
 
     int iterations = 0;
@@ -126,6 +126,9 @@ public class HCdewPointPressureFlash extends ConstantDutyTemperatureFlash {
     if (Math.abs(xtotal - 1.0) >= 1e-5
         || ktot < 1e-3 && system.getPhase(0).getNumberOfComponents() > 1) {
       setSuperCritical(true);
+    }
+    if (isSuperCritical()) {
+      throw new IllegalStateException("System is supercritical");
     }
   }
 

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/SuperCriticalSaturationOpsTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/saturationops/SuperCriticalSaturationOpsTest.java
@@ -1,0 +1,63 @@
+package neqsim.thermodynamicoperations.flashops.saturationops;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemSrkEos;
+
+public class SuperCriticalSaturationOpsTest {
+  @Test
+  void bubblePointThrowsForSupercriticalPureComponent() {
+    SystemSrkEos sys = new SystemSrkEos(300.0, 10.0);
+    sys.addComponent("methane", 1.0);
+    sys.setMixingRule("classic");
+    BubblePointPressureFlash calc = new BubblePointPressureFlash(sys);
+    assertThrows(IllegalStateException.class, calc::run);
+  }
+
+  @Test
+  void dewPointThrowsForSupercriticalPureComponent() {
+    SystemSrkEos sys = new SystemSrkEos(300.0, 10.0);
+    sys.addComponent("methane", 1.0);
+    sys.setMixingRule("classic");
+    DewPointPressureFlash calc = new DewPointPressureFlash(sys);
+    assertThrows(IllegalStateException.class, calc::run);
+  }
+
+  @Test
+  void bubblePointPressureIgnoresHighPressure() {
+    SystemSrkEos sys = new SystemSrkEos(150.0, 100.0);
+    sys.addComponent("methane", 1.0);
+    sys.setMixingRule("classic");
+    BubblePointPressureFlash calc = new BubblePointPressureFlash(sys);
+    assertDoesNotThrow(calc::run);
+  }
+
+  @Test
+  void dewPointPressureIgnoresHighPressure() {
+    SystemSrkEos sys = new SystemSrkEos(150.0, 100.0);
+    sys.addComponent("methane", 1.0);
+    sys.setMixingRule("classic");
+    DewPointPressureFlash calc = new DewPointPressureFlash(sys);
+    assertDoesNotThrow(calc::run);
+  }
+
+  @Test
+  void dewPointTemperatureThrowsForSupercriticalPressure() {
+    SystemSrkEos sys = new SystemSrkEos(150.0, 100.0);
+    sys.addComponent("methane", 1.0);
+    sys.setMixingRule("classic");
+    DewPointTemperatureFlash calc = new DewPointTemperatureFlash(sys);
+    assertThrows(IllegalStateException.class, calc::run);
+  }
+
+  @Test
+  void bubblePointTemperatureThrowsForSupercriticalPressure() {
+    SystemSrkEos sys = new SystemSrkEos(150.0, 100.0);
+    sys.addComponent("methane", 1.0);
+    sys.setMixingRule("classic");
+    BubblePointTemperatureFlash calc = new BubblePointTemperatureFlash(sys);
+    assertThrows(IllegalStateException.class, calc::run);
+  }
+}


### PR DESCRIPTION
## Summary
- Guard bubble/dew **temperature** flashes by comparing system pressure to critical pressure only
- Guard bubble/dew **pressure** flashes only against critical temperature, ignoring system pressure
- Add tests confirming temperature flashes fail above critical pressure while pressure flashes tolerate high pressures

## Testing
- `mvn -q -Dtest=SuperCriticalSaturationOpsTest test`
- `mvn -q test` *(fails: InvalidInputException in REACTIONDATA, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68bbef7896a4832d98b5c6c42e608dfe