### PR TITLE
Handle single-component flash operations

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/VUflashSingleComp.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/VUflashSingleComp.java
@@ -1,0 +1,86 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import neqsim.thermo.phase.PhaseType;
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * <p>
+ * VUflashSingleComp class.
+ * </p>
+ *
+ * @author even solbraa
+ * @version $Id: $Id
+ */
+public class VUflashSingleComp extends Flash {
+  /** Serialization version UID. */
+  private static final long serialVersionUID = 1000;
+
+  double Uspec = 0;
+  double Vspec = 0;
+
+  /**
+   * <p>
+   * Constructor for VUflashSingleComp.
+   * </p>
+   *
+   * @param system a {@link neqsim.thermo.system.SystemInterface} object
+   * @param Vspec a double
+   * @param Uspec a double
+   */
+  public VUflashSingleComp(SystemInterface system, double Vspec, double Uspec) {
+    this.system = system;
+    this.Vspec = Vspec;
+    this.Uspec = Uspec;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void run() {
+    neqsim.thermodynamicoperations.ThermodynamicOperations bubOps =
+        new neqsim.thermodynamicoperations.ThermodynamicOperations(system);
+    double initTemp = system.getTemperature();
+
+    if (system.getPressure() < system.getPhase(0).getComponent(0).getPC()) {
+      try {
+        bubOps.TPflash();
+        if (system.getPhase(0).getType() == PhaseType.GAS) {
+          try {
+            bubOps.dewPointTemperatureFlash();
+          } catch (Exception e) {
+            system.setTemperature(298.0);
+          }
+        } else {
+          bubOps.bubblePointTemperatureFlash();
+        }
+      } catch (Exception ex) {
+        system.setTemperature(initTemp);
+        logger.error(ex.getMessage(), ex);
+      }
+    } else {
+      new VUflash(system, Vspec, Uspec).run();
+      return;
+    }
+
+    system.init(3);
+    double gasU = system.getPhase(0).getInternalEnergy()
+        / system.getPhase(0).getNumberOfMolesInPhase() * system.getTotalNumberOfMoles();
+    double liqU = system.getPhase(1).getInternalEnergy()
+        / system.getPhase(1).getNumberOfMolesInPhase() * system.getTotalNumberOfMoles();
+
+    if (Uspec < liqU || Uspec > gasU) {
+      system.setTemperature(initTemp);
+      new VUflash(system, Vspec, Uspec).run();
+      return;
+    }
+
+    double beta = (Uspec - liqU) / (gasU - liqU);
+    system.setBeta(beta);
+    system.init(3);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public org.jfree.chart.JFreeChart getJFreeChart(String name) {
+    return null;
+  }
+}

--- a/src/test/java/neqsim/thermodynamicoperations/flashops/SingleComponentFlashOpsTest.java
+++ b/src/test/java/neqsim/thermodynamicoperations/flashops/SingleComponentFlashOpsTest.java
@@ -1,0 +1,58 @@
+package neqsim.thermodynamicoperations.flashops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.system.SystemPrEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+class SingleComponentFlashOpsTest {
+  @Test
+  void testPHflashSingleComponent() {
+    SystemPrEos system = new SystemPrEos(273.15, 20.0);
+    system.addComponent("methane", 1.0);
+    system.init(0);
+    ThermodynamicOperations ops = new ThermodynamicOperations(system);
+    ops.TPflash();
+    system.initProperties();
+    double gasH = system.getPhase(0).getEnthalpy()
+        / system.getPhase(0).getNumberOfMolesInPhase() * system.getTotalNumberOfMoles();
+    double liqH = system.getPhase(1).getEnthalpy()
+        / system.getPhase(1).getNumberOfMolesInPhase() * system.getTotalNumberOfMoles();
+    double hSpec = (gasH + liqH) / 2.0;
+    ops.PHflash(hSpec);
+    assertEquals(hSpec, system.getEnthalpy(), 1e-4);
+  }
+
+  @Test
+  void testVUflashSingleComponent() {
+    SystemPrEos system = new SystemPrEos(273.15, 20.0);
+    system.addComponent("methane", 1.0);
+    system.init(0);
+    ThermodynamicOperations ops = new ThermodynamicOperations(system);
+    ops.TPflash();
+    try {
+      ops.bubblePointTemperatureFlash();
+    } catch (Exception e) {
+      try {
+        ops.dewPointTemperatureFlash();
+      } catch (Exception ex) {
+        // ignore
+      }
+    }
+    system.init(3);
+    double gasU = system.getPhase(0).getInternalEnergy()
+        / system.getPhase(0).getNumberOfMolesInPhase() * system.getTotalNumberOfMoles();
+    double liqU = system.getPhase(1).getInternalEnergy()
+        / system.getPhase(1).getNumberOfMolesInPhase() * system.getTotalNumberOfMoles();
+    double gasV = system.getPhase(0).getVolume("m3")
+        / system.getPhase(0).getNumberOfMolesInPhase() * system.getTotalNumberOfMoles();
+    double liqV = system.getPhase(1).getVolume("m3")
+        / system.getPhase(1).getNumberOfMolesInPhase() * system.getTotalNumberOfMoles();
+    double beta = 0.5;
+    double Uspec = liqU + beta * (gasU - liqU);
+    double Vspec = liqV + beta * (gasV - liqV);
+    ops.VUflash(Vspec, Uspec, "m3", "J");
+    assertEquals(beta, system.getBeta(), 1e-6);
+    assertEquals(Vspec, system.getVolume("m3"), 1e-4);
+  }
+}


### PR DESCRIPTION
## Summary
- conditionally use single-component PH/VU algorithms below critical point and within enthalpy or internal energy bounds
- implement dedicated VU flash for pure components that interpolates vapor fraction from internal energy
- consolidate single-component PH and VU flash tests into one class

## Testing
- `mvn -Dtest=SingleComponentFlashOpsTest test`


------
https://chatgpt.com/codex/tasks/task_e_68bbf026ac7c832d9109d19297ede398