### PR TITLE
Handle xsitedni array size dynamically

### DIFF
--- a/src/main/java/neqsim/thermo/ThermodynamicModelSettings.java
+++ b/src/main/java/neqsim/thermo/ThermodynamicModelSettings.java
@@ -11,6 +11,6 @@ package neqsim.thermo;
 public interface ThermodynamicModelSettings extends java.io.Serializable {
   /** Constant <code>phaseFractionMinimumLimit=1e-12</code>. */
   static double phaseFractionMinimumLimit = 1e-12;
-  /** Constant <code>MAX_NUMBER_OF_COMPONENTS=100</code>. */
-  int MAX_NUMBER_OF_COMPONENTS = 100;
+  /** Constant <code>MAX_NUMBER_OF_COMPONENTS=200</code>. */
+  int MAX_NUMBER_OF_COMPONENTS = 200;
 }

--- a/src/main/java/neqsim/thermo/component/ComponentSrkCPA.java
+++ b/src/main/java/neqsim/thermo/component/ComponentSrkCPA.java
@@ -34,10 +34,11 @@ public class ComponentSrkCPA extends ComponentSrk implements ComponentCPAInterfa
    * @param molesInPhase Number of moles in phase.
    * @param compIndex Index number of component in phase object component array.
    */
-  public ComponentSrkCPA(String name, double moles, double molesInPhase, int compIndex) {
+  public ComponentSrkCPA(String name, double moles, double molesInPhase, int compIndex,
+      PhaseInterface phase) {
     super(name, moles, molesInPhase, compIndex);
     xsite = new double[numberOfAssociationSites];
-    xsitedni = new double[numberOfAssociationSites][100];
+    xsitedni = new double[numberOfAssociationSites][phase.getNumberOfComponents()];
     xsitedV = new double[numberOfAssociationSites];
     xsitedT = new double[numberOfAssociationSites];
     xsitedTdT = new double[numberOfAssociationSites];
@@ -75,10 +76,11 @@ public class ComponentSrkCPA extends ComponentSrk implements ComponentCPAInterfa
    * @param a Acentric factor
    * @param moles Total number of moles of component.
    */
-  public ComponentSrkCPA(int number, double TC, double PC, double M, double a, double moles) {
+  public ComponentSrkCPA(int number, double TC, double PC, double M, double a, double moles,
+      PhaseInterface phase) {
     super(number, TC, PC, M, a, moles);
     xsite = new double[numberOfAssociationSites];
-    xsitedni = new double[numberOfAssociationSites][100];
+    xsitedni = new double[numberOfAssociationSites][phase.getNumberOfComponents()];
     xsitedV = new double[numberOfAssociationSites];
     xsitedT = new double[numberOfAssociationSites];
     xsitedTdT = new double[numberOfAssociationSites];
@@ -625,6 +627,27 @@ public class ComponentSrkCPA extends ComponentSrk implements ComponentCPAInterfa
   @Override
   public void setXsitedni(int xnumb, int compnumb, double val) {
     xsitedni[xnumb][compnumb] = val;
+  }
+
+  /**
+   * Ensure that the xsitedni array has capacity for the specified number of components.
+   *
+   * @param numComp desired number of components
+   */
+  public void resizeXsitedni(int numComp) {
+    if (numberOfAssociationSites == 0) {
+      xsitedni = new double[0][0];
+      return;
+    }
+    if (xsitedni.length != numberOfAssociationSites ||
+        (xsitedni.length > 0 && xsitedni[0].length != numComp)) {
+      double[][] newArr = new double[numberOfAssociationSites][numComp];
+      for (int i = 0; i < Math.min(xsitedni.length, numberOfAssociationSites); i++) {
+        System.arraycopy(xsitedni[i], 0, newArr[i], 0,
+            Math.min(xsitedni[i].length, numComp));
+      }
+      xsitedni = newArr;
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/component/ComponentSrkCPAs.java
+++ b/src/main/java/neqsim/thermo/component/ComponentSrkCPAs.java
@@ -24,8 +24,9 @@ public class ComponentSrkCPAs extends ComponentSrkCPA {
    * @param molesInPhase Number of moles in phase.
    * @param compIndex Index number of component in phase object component array.
    */
-  public ComponentSrkCPAs(String name, double moles, double molesInPhase, int compIndex) {
-    super(name, moles, molesInPhase, compIndex);
+  public ComponentSrkCPAs(String name, double moles, double molesInPhase, int compIndex,
+      PhaseInterface phase) {
+    super(name, moles, molesInPhase, compIndex, phase);
   }
 
   /**
@@ -40,8 +41,9 @@ public class ComponentSrkCPAs extends ComponentSrkCPA {
    * @param a Acentric factor
    * @param moles Total number of moles of component.
    */
-  public ComponentSrkCPAs(int number, double TC, double PC, double M, double a, double moles) {
-    super(number, TC, PC, M, a, moles);
+  public ComponentSrkCPAs(int number, double TC, double PC, double M, double a, double moles,
+      PhaseInterface phase) {
+    super(number, TC, PC, M, a, moles, phase);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/phase/PhasePrCPA.java
+++ b/src/main/java/neqsim/thermo/phase/PhasePrCPA.java
@@ -98,7 +98,12 @@ public class PhasePrCPA extends PhasePrEos implements PhaseCPAInterface {
   @Override
   public void addComponent(String name, double moles, double molesInPhase, int compNumber) {
     super.addComponent(name, moles, molesInPhase, compNumber);
-    componentArray[compNumber] = new ComponentSrkCPA(name, moles, molesInPhase, compNumber);
+    componentArray[compNumber] = new ComponentSrkCPA(name, moles, molesInPhase, compNumber, this);
+    for (int i = 0; i < numberOfComponents; i++) {
+      if (componentArray[i] instanceof ComponentSrkCPA) {
+        ((ComponentSrkCPA) componentArray[i]).resizeXsitedni(numberOfComponents);
+      }
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/phase/PhaseSrkCPA.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseSrkCPA.java
@@ -517,7 +517,12 @@ public class PhaseSrkCPA extends PhaseSrkEos implements PhaseCPAInterface {
   @Override
   public void addComponent(String name, double moles, double molesInPhase, int compNumber) {
     super.addComponent(name, moles, molesInPhase, compNumber);
-    componentArray[compNumber] = new ComponentSrkCPA(name, moles, molesInPhase, compNumber);
+    componentArray[compNumber] = new ComponentSrkCPA(name, moles, molesInPhase, compNumber, this);
+    for (int i = 0; i < numberOfComponents; i++) {
+      if (componentArray[i] instanceof ComponentSrkCPA) {
+        ((ComponentSrkCPA) componentArray[i]).resizeXsitedni(numberOfComponents);
+      }
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/phase/PhaseSrkCPA_proceduralMatrices.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseSrkCPA_proceduralMatrices.java
@@ -559,7 +559,12 @@ public class PhaseSrkCPA_proceduralMatrices extends PhaseSrkEos implements Phase
   @Override
   public void addComponent(String name, double moles, double molesInPhase, int compNumber) {
     super.addComponent(name, moles, molesInPhase, compNumber);
-    componentArray[compNumber] = new ComponentSrkCPA(name, moles, molesInPhase, compNumber);
+    componentArray[compNumber] = new ComponentSrkCPA(name, moles, molesInPhase, compNumber, this);
+    for (int i = 0; i < numberOfComponents; i++) {
+      if (componentArray[i] instanceof ComponentSrkCPA) {
+        ((ComponentSrkCPA) componentArray[i]).resizeXsitedni(numberOfComponents);
+      }
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/phase/PhaseSrkCPAs.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseSrkCPAs.java
@@ -2,6 +2,7 @@ package neqsim.thermo.phase;
 
 // import org.ejml.data.DenseMatrix64F;
 
+import neqsim.thermo.component.ComponentSrkCPA;
 import neqsim.thermo.component.ComponentSrkCPAs;
 
 /**
@@ -39,7 +40,12 @@ public class PhaseSrkCPAs extends PhaseSrkCPA {
   @Override
   public void addComponent(String name, double moles, double molesInPhase, int compNumber) {
     super.addComponent(name, moles, molesInPhase, compNumber);
-    componentArray[compNumber] = new ComponentSrkCPAs(name, moles, molesInPhase, compNumber);
+    componentArray[compNumber] = new ComponentSrkCPAs(name, moles, molesInPhase, compNumber, this);
+    for (int i = 0; i < numberOfComponents; i++) {
+      if (componentArray[i] instanceof ComponentSrkCPA) {
+        ((ComponentSrkCPA) componentArray[i]).resizeXsitedni(numberOfComponents);
+      }
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/neqsim/thermo/phase/PhaseSrkCPAsOld.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseSrkCPAsOld.java
@@ -1,5 +1,6 @@
 package neqsim.thermo.phase;
 
+import neqsim.thermo.component.ComponentSrkCPA;
 import neqsim.thermo.component.ComponentSrkCPAs;
 
 /**
@@ -25,7 +26,12 @@ public class PhaseSrkCPAsOld extends PhaseSrkCPAs {
   @Override
   public void addComponent(String name, double moles, double molesInPhase, int compNumber) {
     super.addComponent(name, moles, molesInPhase, compNumber);
-    componentArray[compNumber] = new ComponentSrkCPAs(name, moles, molesInPhase, compNumber);
+    componentArray[compNumber] = new ComponentSrkCPAs(name, moles, molesInPhase, compNumber, this);
+    for (int i = 0; i < numberOfComponents; i++) {
+      if (componentArray[i] instanceof ComponentSrkCPA) {
+        ((ComponentSrkCPA) componentArray[i]).resizeXsitedni(numberOfComponents);
+      }
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/test/java/neqsim/thermo/phase/PhaseSrkCPAArrayScalingTest.java
+++ b/src/test/java/neqsim/thermo/phase/PhaseSrkCPAArrayScalingTest.java
@@ -1,0 +1,37 @@
+package neqsim.thermo.phase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.component.ComponentSrkCPA;
+
+public class PhaseSrkCPAArrayScalingTest {
+
+  private static class DummyPhaseSrkCPA extends PhaseSrkCPA {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void addComponent(String name, double moles, double molesInPhase, int compNumber) {
+      super.addComponent(name, moles, compNumber);
+      ComponentSrkCPA comp = new ComponentSrkCPA(compNumber, 200.0, 50.0, 16.0, 0.1, moles, this);
+      comp.setNumberOfAssociationSites(1);
+      comp.resizeXsitedni(getNumberOfComponents());
+      componentArray[compNumber] = comp;
+      for (int i = 0; i < getNumberOfComponents(); i++) {
+        ((ComponentSrkCPA) componentArray[i]).resizeXsitedni(getNumberOfComponents());
+      }
+    }
+  }
+
+  @Test
+  public void testXsitedniScales() {
+    int n = 120;
+    DummyPhaseSrkCPA phase = new DummyPhaseSrkCPA();
+    for (int i = 0; i < n; i++) {
+      phase.addComponent("c" + i, 1.0, 1.0, i);
+    }
+    for (int i = 0; i < n; i++) {
+      ComponentSrkCPA comp = (ComponentSrkCPA) phase.componentArray[i];
+      assertEquals(n, comp.getXsitedni()[0].length);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- allocate ComponentSrkCPA `xsitedni` arrays based on actual phase component count
- resize `xsitedni` for all components when phases grow
- increase maximum component limit and add a unit test with 120 components

## Testing
- `mvn -Dtest=PhaseSrkCPAArrayScalingTest test`


------
https://chatgpt.com/codex/tasks/task_e_68c02f87b764832dac7657ab673b990f