### PR TITLE
Ensure critical point calculation uses stable phase envelope routine

### DIFF
--- a/src/main/java/neqsim/process/equipment/stream/Stream.java
+++ b/src/main/java/neqsim/process/equipment/stream/Stream.java
@@ -493,7 +493,7 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
     SystemInterface localSyst = getFluid().clone();
     ThermodynamicOperations ops = new ThermodynamicOperations(localSyst);
     ops.setRunAsThread(true);
-    ops.calcPTphaseEnvelope2();
+    ops.calcPTphaseEnvelope();
     ops.waitAndCheckForFinishedCalculation(10000);
     ops.displayResult();
     // ops.getJfreeChart();
@@ -505,7 +505,7 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
     SystemInterface localSyst = getFluid().clone();
     ThermodynamicOperations ops = new ThermodynamicOperations(localSyst);
     ops.setRunAsThread(true);
-    ops.calcPTphaseEnvelope2();
+    ops.calcPTphaseEnvelope();
     ops.waitAndCheckForFinishedCalculation(10000);
     if (unit.equals("bara") || unit.equals("bar")) {
       return ops.get("cricondenbar")[1];
@@ -526,7 +526,7 @@ public class Stream extends ProcessEquipmentBaseClass implements StreamInterface
     SystemInterface localSyst = getFluid().clone();
     ThermodynamicOperations ops = new ThermodynamicOperations(localSyst);
     ops.setRunAsThread(true);
-    ops.calcPTphaseEnvelope2();
+    ops.calcPTphaseEnvelope();
     ops.waitAndCheckForFinishedCalculation(10000);
     if (unit.equals("bara") || unit.equals("bar")) {
       return ops.get("cricondentherm")[1];


### PR DESCRIPTION
## Summary
- use `calcPTphaseEnvelope` instead of the newer algorithm when computing cricondenbar and cricondentherm
- avoids Java 8 discrepancies in `Stream.CCB` and `Stream.CCT`

## Testing
- `mvn -Dtest=EclipseFluidReadWriteTest#testReadBrd test`


------
https://chatgpt.com/codex/tasks/task_e_68c071eb108c832db67dc1ce75620e1b