### PR TITLE
Implement Rackett Z for Twu and Lee-Kesler models

### DIFF
--- a/src/main/java/neqsim/thermo/characterization/TBPfractionModel.java
+++ b/src/main/java/neqsim/thermo/characterization/TBPfractionModel.java
@@ -423,6 +423,13 @@ public class TBPfractionModel implements java.io.Serializable {
     public double calcAcentricFactor(double molarMass, double density) {
       return super.calcAcentricFactorKeslerLee(molarMass, density);
     }
+
+    /** {@inheritDoc} */
+    @Override
+    public double calcRacketZ(SystemInterface thermoSystem, double molarMass, double density) {
+      double acs = calcAcentricFactor(molarMass, density);
+      return 0.29056 - 0.08775 * acs;
+    }
   }
 
   /**
@@ -550,6 +557,13 @@ public class TBPfractionModel implements java.io.Serializable {
       double PC = PCnalkane * (TC / Tcnalkane) * (VCnalkane / VC)
           * Math.pow(((1 + 2 * fP) / (1 - 2 * fP)), 2);
       return VC * 1e3; // m3/mol
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double calcRacketZ(SystemInterface thermoSystem, double molarMass, double density) {
+      double acs = calcAcentricFactor(molarMass, density);
+      return 0.29056 - 0.08775 * acs;
     }
   }
 

--- a/src/test/java/neqsim/thermo/characterization/TBPfractionModelTest.java
+++ b/src/test/java/neqsim/thermo/characterization/TBPfractionModelTest.java
@@ -16,6 +16,7 @@ public class TBPfractionModelTest {
     assertEquals(26.52357312690, thermoSystem.getComponent(0).getPC(), 1e-3);
     assertEquals(0.56001213933, thermoSystem.getComponent(0).getAcentricFactor(), 1e-3);
     assertEquals(437.335493, thermoSystem.getComponent(0).getCriticalVolume(), 1e-3);
+    assertEquals(0.24141893477, thermoSystem.getComponent(0).getRacketZ(), 1e-3);
   }
 
   @Test
@@ -27,6 +28,7 @@ public class TBPfractionModelTest {
     assertEquals(28.322987349048354, thermoSystem.getComponent(0).getPC(), 1e-3);
     assertEquals(0.3509842412742902, thermoSystem.getComponent(0).getAcentricFactor(), 1e-3);
     assertEquals(427.99744457199, thermoSystem.getComponent(0).getCriticalVolume(), 1e-3);
+    assertEquals(0.25976113283, thermoSystem.getComponent(0).getRacketZ(), 1e-3);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Add Rackett Z correlation to Lee-Kesler and Twu TBP models
- Verify Rackett Z in Twu and Lee-Kesler unit tests

## Testing
- `mvn -e -Dtest=TBPfractionModelTest test`


------
https://chatgpt.com/codex/tasks/task_e_68c091b8b3dc832d82b820b7675ea83b