### PR TITLE
Add Joule-Thomson coefficient to Span-Wagner CO₂ model

### DIFF
--- a/src/main/java/neqsim/thermo/phase/PhaseSpanWagnerEos.java
+++ b/src/main/java/neqsim/thermo/phase/PhaseSpanWagnerEos.java
@@ -18,6 +18,7 @@ public class PhaseSpanWagnerEos extends PhaseEos {
   private double internalEnergy; // J/mol
   private double soundSpeed; // m/s
   private double molarDensity; // mol/m3
+  private double jouleThomson; // K/Pa
 
   public PhaseSpanWagnerEos() {
     thermoPropertyModelName = "Span-Wagner";
@@ -50,6 +51,7 @@ public class PhaseSpanWagnerEos extends PhaseEos {
       gibbsEnergy = props[7];
       soundSpeed = props[8];
       getComponent(0).setFugacityCoefficient(props[9]);
+      jouleThomson = props[10];
       if (molarDensity > 1500.0) {
         setType(PhaseType.LIQUID);
       } else {
@@ -98,7 +100,12 @@ public class PhaseSpanWagnerEos extends PhaseEos {
   }
 
   @Override
+  public double getJouleThomsonCoefficient() {
+    return jouleThomson * 1e5;
+  }
+
+  @Override
   public double molarVolume(double pressure, double temperature, double A, double B, PhaseType pt) {
-    return 1.0 / molarDensity;
+    return 1.0 / molarDensity * 1e5;
   }
 }

--- a/src/main/java/neqsim/thermo/util/spanwagner/NeqSimSpanWagner.java
+++ b/src/main/java/neqsim/thermo/util/spanwagner/NeqSimSpanWagner.java
@@ -151,7 +151,7 @@ public final class NeqSimSpanWagner {
    *
    * @param temperature Kelvin
    * @param pressure Pascal
-   * @return array [rho, Z, h, s, cp, cv, u, g, w]
+   * @return array [rho, Z, h, s, cp, cv, u, g, w, phi, JT]
    */
   public static double[] getProperties(double temperature, double pressure, PhaseType type) {
     double tau = TC / temperature;
@@ -175,10 +175,12 @@ public final class NeqSimSpanWagner {
     double dPdrho = R * temperature * (1 + 2 * delta * d.ar_d + delta * delta * d.ar_dd);
     double w2 = cp / cv * dPdrho / 0.0440098; // molar mass kg/mol
     double w = Math.sqrt(w2);
+    double dPdT = R * rho * (1 + delta * d.ar_d - delta * tau * d.ar_dt);
+    double muJT = 1.0 / cp * (temperature / (rho * rho) * (dPdT / dPdrho) - 1.0 / rho);
     double lnPhi = d.ar + delta * d.ar_d - Math.log(Z);
     double phi = Math.exp(lnPhi);
 
-    return new double[] {rho, Z, h, s, cp, cv, u, g, w, phi};
+    return new double[] {rho, Z, h, s, cp, cv, u, g, w, phi, muJT};
   }
 }
 

--- a/src/test/java/neqsim/thermo/util/spanwagner/SpanWagnerGERGComparisonTest.java
+++ b/src/test/java/neqsim/thermo/util/spanwagner/SpanWagnerGERGComparisonTest.java
@@ -1,0 +1,60 @@
+package neqsim.thermo.util.spanwagner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import neqsim.thermo.phase.PhaseInterface;
+import neqsim.thermo.system.SystemGERG2008Eos;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSpanWagnerEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Regression tests comparing Span–Wagner and GERG‑2008 properties for CO₂.
+ */
+public class SpanWagnerGERGComparisonTest {
+
+  private double[] getSpanWagnerProps(double temperature, double pressure) {
+    SystemInterface sys = new SystemSpanWagnerEos(temperature, pressure);
+    sys.init(0);
+    sys.init(1);
+    sys.init(2);
+    sys.init(3);
+    PhaseInterface phase = sys.getPhase(0);
+    double moles = phase.getNumberOfMolesInPhase();
+    return new double[] {phase.getCp() / moles, phase.getCv() / moles, phase.getSoundSpeed(),
+        phase.getJouleThomsonCoefficient(), phase.getDensity()};
+  }
+
+  private double[] getGERGProps(double temperature, double pressure) {
+    SystemInterface sys = new SystemGERG2008Eos(temperature, pressure);
+    sys.addComponent("CO2", 1.0);
+    sys.createDatabase(true);
+    sys.setMixingRule(2);
+    new ThermodynamicOperations(sys).TPflash();
+    sys.initProperties();
+    PhaseInterface phase = sys.getPhase(0);
+    double moles = phase.getNumberOfMolesInPhase();
+    return new double[] {phase.getCp() / moles, phase.getCv() / moles, phase.getSoundSpeed(),
+        phase.getJouleThomsonCoefficient(), phase.getDensity()};
+  }
+
+  private void compareAtPressure(double pressure) {
+    double temperature = 298.15;
+    double[] span = getSpanWagnerProps(temperature, pressure);
+    double[] gerg = getGERGProps(temperature, pressure);
+    for (int i = 0; i < span.length; i++) {
+      assertEquals(gerg[i], span[i], Math.abs(gerg[i]) * 1e-2 + 1e-8);
+    }
+  }
+
+  @Test
+  public void testLowPressure() {
+    compareAtPressure(10.0);
+  }
+
+  @Test
+  public void testHighPressure() {
+    compareAtPressure(100.0);
+  }
+}

--- a/src/test/java/neqsim/thermo/util/spanwagner/SpanWagnerTest.java
+++ b/src/test/java/neqsim/thermo/util/spanwagner/SpanWagnerTest.java
@@ -25,7 +25,7 @@ public class SpanWagnerTest {
     init(sys);
     PhaseInterface phase = sys.getPhase(0);
     double moles = phase.getNumberOfMolesInPhase();
-    assertEquals(422.164519, 1.0 / phase.getMolarVolume(), 1e-3);
+    assertEquals(422.164519, phase.getDensity() / phase.getMolarMass(), 1e-3);
     assertEquals(0.94964297, phase.getZ(), 1e-6);
     assertEquals(21953.7555, phase.getEnthalpy() / moles, 1e-2);
     assertEquals(100.754536, phase.getEntropy() / moles, 1e-3);
@@ -34,6 +34,7 @@ public class SpanWagnerTest {
     assertEquals(19585.0108, phase.getInternalEnergy() / moles, 1e-2);
     assertEquals(-8272.60538, phase.getGibbsEnergy() / moles, 1e-2);
     assertEquals(262.43047, phase.getSoundSpeed(), 1e-2);
+    assertEquals(1.0801733, phase.getJouleThomsonCoefficient(), 1e-6);
   }
 
   @Test
@@ -42,7 +43,7 @@ public class SpanWagnerTest {
     init(sys);
     PhaseInterface phase = sys.getPhase(1);
     double moles = phase.getNumberOfMolesInPhase();
-    assertEquals(20311.453, 1.0 / phase.getMolarVolume(), 0.2);
+    assertEquals(20311.453, phase.getDensity() / phase.getMolarMass(), 0.2);
     assertEquals(0.10573879, phase.getZ(), 1e-5);
     assertEquals(9501.661, phase.getEnthalpy() / moles, 0.2);
     assertEquals(46.275024, phase.getEntropy() / moles, 0.02);
@@ -51,6 +52,7 @@ public class SpanWagnerTest {
     assertEquals(9255.495, phase.getInternalEnergy() / moles, 0.2);
     assertEquals(-3455.3457, phase.getGibbsEnergy() / moles, 0.2);
     assertEquals(495.5176, phase.getSoundSpeed(), 0.1);
+    assertEquals(0.0568959, phase.getJouleThomsonCoefficient(), 1e-6);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- compute Joule–Thomson coefficient and analytic pressure derivative in `NeqSimSpanWagner`
- expose new coefficient in `PhaseSpanWagnerEos` and scale molar volume to internal units
- add regression tests comparing Span–Wagner to GERG-2008 for Cp, Cv, sound speed, JT coefficient, and density

## Testing
- `mvn -Dtest=neqsim.thermo.util.spanwagner.SpanWagnerTest test`
- `mvn -Dtest=neqsim.thermo.util.spanwagner.SpanWagnerGERGComparisonTest test`
- `mvn test -q` *(failed: process terminated due to excessive output)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c305907c832d8e6de6d783b9db52