### PR TITLE
Add controller set point getter for PID controllers

### DIFF
--- a/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
+++ b/src/main/java/neqsim/process/controllerdevice/ControllerDeviceBaseClass.java
@@ -224,6 +224,12 @@ public class ControllerDeviceBaseClass extends NamedBaseClass implements Control
 
   /** {@inheritDoc} */
   @Override
+  public double getControllerSetPoint() {
+    return controllerSetPoint;
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public String getUnit() {
     return unit;
   }

--- a/src/main/java/neqsim/process/controllerdevice/ControllerDeviceInterface.java
+++ b/src/main/java/neqsim/process/controllerdevice/ControllerDeviceInterface.java
@@ -60,6 +60,15 @@ public interface ControllerDeviceInterface extends java.io.Serializable {
 
   /**
    * <p>
+   * getControllerSetPoint.
+   * </p>
+   *
+   * @return current controller set point
+   */
+  public double getControllerSetPoint();
+
+  /**
+   * <p>
    * getUnit.
    * </p>
    *

--- a/src/test/java/neqsim/process/controllerdevice/ControlStructureTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/ControlStructureTest.java
@@ -30,6 +30,11 @@ public class ControlStructureTest {
     }
 
     @Override
+    public double getControllerSetPoint() {
+      return setPoint;
+    }
+
+    @Override
     public String getUnit() {
       return "";
     }

--- a/src/test/java/neqsim/process/controllerdevice/ControllerDeviceBaseClassTest.java
+++ b/src/test/java/neqsim/process/controllerdevice/ControllerDeviceBaseClassTest.java
@@ -94,4 +94,11 @@ public class ControllerDeviceBaseClassTest {
     c.setUnit(oldUnit);
     Assertions.assertEquals(oldUnit, c.getUnit());
   }
+
+  @Test
+  void testGetControllerSetPoint() {
+    double setPoint = 5.0;
+    c.setControllerSetPoint(setPoint);
+    Assertions.assertEquals(setPoint, c.getControllerSetPoint());
+  }
 }


### PR DESCRIPTION
## Summary
- expose controller set point through new `getControllerSetPoint` method
- implement getter in `ControllerDeviceBaseClass`
- update control structure tests and add unit test for set point retrieval

## Testing
- `mvn -Dtest=ControllerDeviceBaseClassTest,ControlStructureTest test`

------
https://chatgpt.com/codex/tasks/task_e_68c6756d7800832da7cba21bb0e484de