### PR TITLE
Add oil choke optimization test

### DIFF
--- a/src/main/java/neqsim/process/equipment/network/WellFlowlineNetwork.java
+++ b/src/main/java/neqsim/process/equipment/network/WellFlowlineNetwork.java
@@ -1,0 +1,605 @@
+package neqsim.process.equipment.network;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import neqsim.process.equipment.ProcessEquipmentBaseClass;
+import neqsim.process.equipment.mixer.Mixer;
+import neqsim.process.equipment.pipeline.PipeBeggsAndBrills;
+import neqsim.process.equipment.reservoir.WellFlow;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.util.unit.PressureUnit;
+
+/**
+ * Network wrapper that links {@link WellFlow} inflow models with {@link PipeBeggsAndBrills}
+ * hydraulics and gathers the outlets into configurable manifolds.
+ */
+public class WellFlowlineNetwork extends ProcessEquipmentBaseClass {
+  private static final long serialVersionUID = 1000L;
+
+  /** A branch represents one well + flowline path to a manifold. */
+  public static class Branch {
+    private final String name;
+    private final WellFlow well;
+    private final PipeBeggsAndBrills pipeline;
+    private ThrottlingValve choke;
+
+    Branch(String name, WellFlow well, PipeBeggsAndBrills pipeline, ThrottlingValve choke) {
+      this.name = name;
+      this.well = well;
+      this.pipeline = pipeline;
+      this.choke = choke;
+      updatePipelineInlet();
+    }
+
+    private void updatePipelineInlet() {
+      if (choke != null) {
+        choke.setInletStream(well.getOutletStream());
+        pipeline.setInletStream(choke.getOutletStream());
+      } else {
+        pipeline.setInletStream(well.getOutletStream());
+      }
+    }
+
+    /** Run steady-state inflow and hydraulics for this branch. */
+    void run(UUID id) {
+      well.run(id);
+      if (choke != null) {
+        choke.run(id);
+      }
+      pipeline.run(id);
+    }
+
+    /** Run transient inflow and hydraulics for this branch. */
+    void runTransient(double dt, UUID id) {
+      well.runTransient(dt, id);
+      if (choke != null) {
+        choke.runTransient(dt, id);
+      }
+      pipeline.runTransient(dt, id);
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public WellFlow getWell() {
+      return well;
+    }
+
+    public PipeBeggsAndBrills getPipeline() {
+      return pipeline;
+    }
+
+    public ThrottlingValve getChoke() {
+      return choke;
+    }
+
+    public void setChoke(ThrottlingValve choke) {
+      this.choke = choke;
+      updatePipelineInlet();
+    }
+  }
+
+  /**
+   * Represents a manifold that mixes incoming branches (and optional upstream pipeline) before
+   * optionally sending flow further downstream through a connecting pipeline.
+   */
+  public static class ManifoldNode {
+    private final String name;
+    private final Mixer mixer;
+    private final List<Branch> branches = new ArrayList<>();
+    private final List<PipeBeggsAndBrills> inboundPipelines = new ArrayList<>();
+    private PipeBeggsAndBrills pipelineToNext;
+
+    ManifoldNode(String name) {
+      this.name = name;
+      this.mixer = new Mixer(name + " mixer");
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public Mixer getMixer() {
+      return mixer;
+    }
+
+    public List<Branch> getBranches() {
+      return Collections.unmodifiableList(branches);
+    }
+
+    void addBranch(Branch branch) {
+      branches.add(branch);
+      mixer.addStream(branch.getPipeline().getOutletStream());
+    }
+
+    void addInboundPipeline(PipeBeggsAndBrills pipeline) {
+      if (pipeline != null) {
+        inboundPipelines.add(pipeline);
+        mixer.addStream(pipeline.getOutletStream());
+      }
+    }
+
+    List<PipeBeggsAndBrills> getInboundPipelines() {
+      return Collections.unmodifiableList(inboundPipelines);
+    }
+
+    void setPipelineToNext(PipeBeggsAndBrills pipelineToNext) {
+      this.pipelineToNext = pipelineToNext;
+    }
+
+    PipeBeggsAndBrills getPipelineToNext() {
+      return pipelineToNext;
+    }
+  }
+
+  private final List<ManifoldNode> manifolds = new ArrayList<>();
+  private PipeBeggsAndBrills facilityPipeline;
+  private boolean propagateArrivalPressureToWells = true;
+  private boolean forceFlowFromPressureSolve = true;
+  private Double targetEndpointPressure;
+  private String targetEndpointPressureUnit = "bara";
+  private double iterationTolerance = 1.0e-4;
+  private int maxIterations = 20;
+  private Double lastTerminalManifoldPressure;
+
+  /**
+   * Create a new network wrapper.
+   *
+   * @param name network name
+   */
+  public WellFlowlineNetwork(String name) {
+    super(name);
+    manifolds.add(new ManifoldNode(name + " arrival manifold"));
+  }
+
+  /**
+   * Create an unconnected manifold node that can later be linked to other manifolds via pipelines.
+   *
+   * @param name manifold name
+   * @return the created {@link ManifoldNode}
+   */
+  public ManifoldNode createManifold(String name) {
+    ManifoldNode node = new ManifoldNode(name);
+    manifolds.add(node);
+    return node;
+  }
+
+  /**
+   * Add a branch to the network using preconfigured well and pipeline units. The pipeline inlet is
+   * forced to the well outlet and its outlet is attached to the terminal manifold by default.
+   *
+   * @param branchName branch identifier
+   * @param well configured {@link WellFlow}
+   * @param pipeline configured {@link PipeBeggsAndBrills}
+   * @return the added {@link Branch}
+   */
+  public Branch addBranch(String branchName, WellFlow well, PipeBeggsAndBrills pipeline) {
+    return addBranch(branchName, well, pipeline, null, getTailManifold());
+  }
+
+  /**
+   * Add a branch to a specific manifold in the network.
+   *
+   * @param branchName branch identifier
+   * @param well configured {@link WellFlow}
+   * @param pipeline configured {@link PipeBeggsAndBrills}
+   * @param manifold manifold that should receive the branch outlet
+   * @return the added {@link Branch}
+   */
+  public Branch addBranch(String branchName, WellFlow well, PipeBeggsAndBrills pipeline,
+      ManifoldNode manifold) {
+    return addBranch(branchName, well, pipeline, null, manifold);
+  }
+
+  /**
+   * Add a branch with an optional production choke to a specific manifold.
+   *
+   * @param branchName branch identifier
+   * @param well configured {@link WellFlow}
+   * @param pipeline configured {@link PipeBeggsAndBrills}
+   * @param choke optional {@link ThrottlingValve} placed between the well outlet and pipeline inlet
+   * @param manifold manifold that should receive the branch outlet
+   * @return the added {@link Branch}
+   */
+  public Branch addBranch(String branchName, WellFlow well, PipeBeggsAndBrills pipeline,
+      ThrottlingValve choke, ManifoldNode manifold) {
+    Objects.requireNonNull(well, "well cannot be null");
+    Objects.requireNonNull(pipeline, "pipeline cannot be null");
+    Objects.requireNonNull(manifold, "manifold cannot be null");
+    Branch branch = new Branch(branchName, well, pipeline, choke);
+    manifold.addBranch(branch);
+    return branch;
+  }
+
+  /**
+   * Convenience helper that creates a branch from a reservoir stream by instantiating a
+   * {@link WellFlow} and {@link PipeBeggsAndBrills} pair and attaching it to the terminal manifold.
+   *
+   * @param branchName branch identifier
+   * @param reservoirStream stream representing reservoir inflow
+   * @return the created {@link Branch}
+   */
+  public Branch addBranch(String branchName, StreamInterface reservoirStream) {
+    return addBranch(branchName, reservoirStream, getTailManifold());
+  }
+
+  /**
+   * Convenience helper that creates a branch from a reservoir stream for a specific manifold.
+   *
+   * @param branchName branch identifier
+   * @param reservoirStream stream representing reservoir inflow
+   * @param manifold manifold that should receive the branch outlet
+   * @return the created {@link Branch}
+   */
+  public Branch addBranch(String branchName, StreamInterface reservoirStream, ManifoldNode manifold) {
+    WellFlow well = new WellFlow(branchName + " well");
+    well.setInletStream(reservoirStream);
+    PipeBeggsAndBrills pipeline = new PipeBeggsAndBrills(branchName + " pipeline",
+        well.getOutletStream());
+    return addBranch(branchName, well, pipeline, null, manifold);
+  }
+
+  /**
+   * Get an immutable view of network branches for optimization or tuning.
+   *
+   * @return list of branches
+   */
+  public List<Branch> getBranches() {
+    List<Branch> allBranches = new ArrayList<>();
+    for (ManifoldNode manifold : manifolds) {
+      allBranches.addAll(manifold.getBranches());
+    }
+    return Collections.unmodifiableList(allBranches);
+  }
+
+  /**
+   * Get the configured manifolds in upstream-to-downstream order.
+   *
+   * @return manifolds
+   */
+  public List<ManifoldNode> getManifolds() {
+    return Collections.unmodifiableList(manifolds);
+  }
+
+  /**
+   * Get the arrival mixer that gathers all branch outlets (useful for reporting or re-routing).
+   *
+   * @return arrival mixer
+   */
+  public Mixer getArrivalMixer() {
+    return getTailManifold().getMixer();
+  }
+
+  /**
+   * Attach a common pipeline from the arrival manifold to the receiving facility. The pipeline
+   * inlet is automatically wired to the terminal manifold outlet.
+   *
+   * @param pipeline configured {@link PipeBeggsAndBrills} representing the shared pipeline
+   */
+  public void setFacilityPipeline(PipeBeggsAndBrills pipeline) {
+    this.facilityPipeline = pipeline;
+    if (pipeline != null) {
+      pipeline.setInletStream(getTailManifold().getMixer().getOutletStream());
+    }
+  }
+
+  /**
+   * Add an additional manifold downstream of the current endpoint, connecting it with the supplied
+   * pipeline. The pipeline inlet is automatically wired to the current terminal manifold outlet.
+   *
+   * @param name manifold name
+   * @param connectionPipeline pipeline from the current endpoint manifold to the new manifold
+   * @return the created {@link ManifoldNode}
+   */
+  public ManifoldNode addManifold(String name, PipeBeggsAndBrills connectionPipeline) {
+    Objects.requireNonNull(connectionPipeline, "connectionPipeline cannot be null");
+    ManifoldNode previousTail = getTailManifold();
+    connectionPipeline.setInletStream(previousTail.getMixer().getOutletStream());
+    previousTail.setPipelineToNext(connectionPipeline);
+
+    ManifoldNode newNode = new ManifoldNode(name);
+    newNode.addInboundPipeline(connectionPipeline);
+    manifolds.add(newNode);
+    return newNode;
+  }
+
+  /**
+   * Connect an upstream manifold to a downstream manifold using the provided pipeline.
+   *
+   * @param upstream upstream manifold
+   * @param downstream downstream manifold that should receive the pipeline outlet
+   * @param connectionPipeline pipeline from upstream to downstream
+   */
+  public void connectManifolds(ManifoldNode upstream, ManifoldNode downstream,
+      PipeBeggsAndBrills connectionPipeline) {
+    Objects.requireNonNull(upstream, "upstream manifold cannot be null");
+    Objects.requireNonNull(downstream, "downstream manifold cannot be null");
+    Objects.requireNonNull(connectionPipeline, "connectionPipeline cannot be null");
+    connectionPipeline.setInletStream(upstream.getMixer().getOutletStream());
+    upstream.setPipelineToNext(connectionPipeline);
+    downstream.addInboundPipeline(connectionPipeline);
+  }
+
+  /**
+   * Control whether the arrival pressure should be pushed back to wells that are configured to
+   * compute flow from outlet pressure (production-index, Vogel, or Fetkovich modes with
+   * {@code solveFlowFromOutletPressure(true)}).
+   *
+   * @param propagate true to push arrival pressure back to wells
+   */
+  public void setPropagateArrivalPressureToWells(boolean propagate) {
+    this.propagateArrivalPressureToWells = propagate;
+  }
+
+  /**
+   * Automatically switch wells to solve for flow from outlet pressure when running with a specified
+   * target endpoint pressure.
+   *
+   * @param enable true to force wells to solve for flow from pressure
+   */
+  public void setForceFlowFromPressureSolve(boolean enable) {
+    this.forceFlowFromPressureSolve = enable;
+  }
+
+  /**
+   * Specify the desired pressure at the network endpoint (arrival manifold if no facility pipeline,
+   * otherwise the facility pipeline outlet). The network will iterate manifold pressure to match
+   * this target while solving individual well rates from backpressure.
+   *
+   * @param pressure target endpoint pressure
+   * @param unit pressure unit
+   */
+  public void setTargetEndpointPressure(double pressure, String unit) {
+    this.targetEndpointPressure = new PressureUnit(pressure, unit).getValue("bara");
+    this.targetEndpointPressureUnit = unit;
+  }
+
+  /**
+   * Configure convergence tolerance when iterating manifold pressure to reach the target endpoint
+   * pressure.
+   *
+   * @param tolerance absolute pressure tolerance in bara
+   */
+  public void setIterationTolerance(double tolerance) {
+    this.iterationTolerance = tolerance;
+  }
+
+  /**
+   * Configure maximum number of iterations when matching target endpoint pressure.
+   *
+   * @param maxIterations iteration cap
+   */
+  public void setMaxIterations(int maxIterations) {
+    this.maxIterations = maxIterations;
+  }
+
+  /**
+   * Stream representing combined arrival conditions at the platform inlet.
+   *
+   * @return arrival stream
+   */
+  public StreamInterface getArrivalStream() {
+    return getTailManifold().getMixer().getOutletStream();
+  }
+
+  /**
+   * Report the most recent pressure enforced at the terminal manifold while solving toward a
+   * target endpoint pressure.
+   *
+   * @param unit requested unit
+   * @return terminal manifold pressure, or {@code null} if the network has not been run
+   */
+  public Double getTerminalManifoldPressure(String unit) {
+    if (lastTerminalManifoldPressure == null) {
+      return null;
+    }
+    return new PressureUnit(lastTerminalManifoldPressure, "bara").getValue(unit);
+  }
+
+  @Override
+  public void run(UUID id) {
+    if (getBranches().isEmpty()) {
+      return;
+    }
+    if (targetEndpointPressure != null) {
+      iterateForEndpointPressure(id);
+    } else {
+      runManifolds(id, false, null);
+      if (facilityPipeline != null) {
+        facilityPipeline.setInletStream(getTailManifold().getMixer().getOutletStream());
+        facilityPipeline.run(id);
+      }
+      enforceManifoldPressures(id);
+    }
+  }
+
+  @Override
+  public void runTransient(double dt, UUID id) {
+    if (getBranches().isEmpty()) {
+      return;
+    }
+    if (targetEndpointPressure != null) {
+      iterateForEndpointPressure(id);
+    } else {
+      for (ManifoldNode manifold : manifolds) {
+        for (Branch branch : manifold.getBranches()) {
+          branch.runTransient(dt, id);
+        }
+        // Mixer has no dedicated transient API; recompute arrival conditions after transient steps.
+        manifold.getMixer().run(id);
+        if (manifold.getPipelineToNext() != null) {
+          manifold.getPipelineToNext().setInletStream(manifold.getMixer().getOutletStream());
+          manifold.getPipelineToNext().runTransient(dt, id);
+        }
+      }
+      if (facilityPipeline != null) {
+        facilityPipeline.setInletStream(getTailManifold().getMixer().getOutletStream());
+        facilityPipeline.runTransient(dt, id);
+      }
+      enforceManifoldPressures(id);
+    }
+  }
+
+  @Override
+  public void setName(String name) {
+    super.setName(name);
+    if (!manifolds.isEmpty()) {
+      manifolds.get(manifolds.size() - 1).getMixer().setName(name + " arrival mixer");
+    }
+  }
+
+  @Override
+  public String toJson() {
+    if (getBranches().isEmpty()) {
+      return null;
+    }
+    // Defer to the arrival mixer JSON for a concise snapshot of network outlet conditions.
+    return getTailManifold().getMixer().toJson();
+  }
+
+  /**
+   * Force a single pressure at each manifold outlet and optionally push that backpressure to wells
+   * that solve for flow from outlet pressure.
+   */
+  private void enforceManifoldPressures(UUID id) {
+    if (getBranches().isEmpty()) {
+      return;
+    }
+
+    for (ManifoldNode manifold : manifolds) {
+      double manifoldPressure = manifold.getMixer().getOutletStream().getPressure("bara");
+
+      for (Branch branch : manifold.getBranches()) {
+        branch.getPipeline().getOutletStream().setPressure(manifoldPressure, "bara");
+        if (branch.getChoke() != null) {
+          branch.getChoke().getOutletStream().setPressure(manifoldPressure, "bara");
+        }
+        if (propagateArrivalPressureToWells && !branch.getWell().isCalculatingOutletPressure()) {
+          branch.getWell().setOutletPressure(manifoldPressure, "bara");
+        }
+      }
+
+      for (PipeBeggsAndBrills inbound : manifold.getInboundPipelines()) {
+        inbound.getOutletStream().setPressure(manifoldPressure, "bara");
+      }
+
+      // Recompute combined arrival with harmonized pressures.
+      manifold.getMixer().run(id);
+    }
+
+    if (facilityPipeline != null) {
+      facilityPipeline.run(id);
+    }
+  }
+
+  /**
+   * Iteratively adjust terminal manifold pressure so that the endpoint (arrival or facility outlet)
+   * pressure matches the configured target.
+   */
+  private void iterateForEndpointPressure(UUID id) {
+    double manifoldGuess = targetEndpointPressure;
+    double achievedPressure = runWithEndpointPressure(manifoldGuess, id);
+
+    for (int i = 0; i < maxIterations
+        && Math.abs(achievedPressure - targetEndpointPressure) > iterationTolerance; i++) {
+      double error = achievedPressure - targetEndpointPressure;
+      manifoldGuess = Math.max(0.1, manifoldGuess - error);
+      achievedPressure = runWithEndpointPressure(manifoldGuess, id);
+    }
+
+    // Harmonize pressures after the final iteration to keep branch and manifold streams aligned
+    // with the terminal pressure used to hit the endpoint target.
+    enforceManifoldPressures(id);
+  }
+
+  /**
+   * Execute branch runs and facility pipeline while enforcing a specified terminal manifold
+   * pressure.
+   *
+   * @param manifoldPressure pressure in bara at the terminal manifold
+   * @param id calculation identifier
+   * @return pressure achieved at the endpoint (arrival if no facility pipeline, otherwise facility
+   *         pipeline outlet)
+   */
+  private double runWithEndpointPressure(double manifoldPressure, UUID id) {
+    lastTerminalManifoldPressure = manifoldPressure;
+    runManifolds(id, true, manifoldPressure);
+
+    if (facilityPipeline != null) {
+      facilityPipeline.setInletStream(getTailManifold().getMixer().getOutletStream());
+      facilityPipeline.run(id);
+      return facilityPipeline.getOutletStream().getPressure("bara");
+    }
+
+    return getTailManifold().getMixer().getOutletStream().getPressure("bara");
+  }
+
+  /**
+   * Run through all manifolds and branches in upstream-to-downstream order.
+   */
+  private void runManifolds(UUID id, boolean forceEndpointPressure, Double endpointPressure) {
+    for (int i = 0; i < manifolds.size(); i++) {
+      ManifoldNode manifold = manifolds.get(i);
+      boolean isTerminal = i == manifolds.size() - 1;
+      runManifold(manifold, id, forceEndpointPressure && isTerminal, endpointPressure);
+    }
+  }
+
+  private void runManifold(ManifoldNode manifold, UUID id, boolean overridePressure,
+      Double forcedPressure) {
+    for (PipeBeggsAndBrills inbound : manifold.getInboundPipelines()) {
+      inbound.run(id);
+    }
+
+    for (Branch branch : manifold.getBranches()) {
+      if (forceFlowFromPressureSolve && branch.getWell().isCalculatingOutletPressure()) {
+        branch.getWell().solveFlowFromOutletPressure(true);
+      }
+      if (overridePressure && forcedPressure != null) {
+        if (branch.getChoke() != null) {
+          branch.getChoke().setOutletPressure(forcedPressure, "bara");
+        }
+        branch.getWell().setOutletPressure(forcedPressure, "bara");
+      }
+      branch.run(id);
+    }
+
+    manifold.getMixer().run(id);
+
+    double manifoldPressure = manifold.getMixer().getOutletStream().getPressure("bara");
+    if (overridePressure && forcedPressure != null) {
+      manifoldPressure = forcedPressure;
+      manifold.getMixer().getOutletStream().setPressure(manifoldPressure, "bara");
+    }
+
+    for (Branch branch : manifold.getBranches()) {
+      branch.getPipeline().getOutletStream().setPressure(manifoldPressure, "bara");
+      if (branch.getChoke() != null) {
+        branch.getChoke().getOutletStream().setPressure(manifoldPressure, "bara");
+      }
+      if (propagateArrivalPressureToWells && !branch.getWell().isCalculatingOutletPressure()) {
+        branch.getWell().setOutletPressure(manifoldPressure, "bara");
+      }
+    }
+
+    for (PipeBeggsAndBrills inbound : manifold.getInboundPipelines()) {
+      inbound.getOutletStream().setPressure(manifoldPressure, "bara");
+    }
+
+    manifold.getMixer().run(id);
+
+    if (manifold.getPipelineToNext() != null) {
+      manifold.getPipelineToNext().setInletStream(manifold.getMixer().getOutletStream());
+      manifold.getPipelineToNext().run(id);
+    }
+  }
+
+  private ManifoldNode getTailManifold() {
+    return manifolds.get(manifolds.size() - 1);
+  }
+}

--- a/src/main/java/neqsim/process/equipment/reservoir/WellFlow.java
+++ b/src/main/java/neqsim/process/equipment/reservoir/WellFlow.java
@@ -172,6 +172,35 @@ public class WellFlow extends TwoPortEquipment {
   }
 
   /**
+   * Specify the well outlet pressure to be used when solving for flow from backpressure
+   * (i.e. {@link #solveFlowFromOutletPressure(boolean)} set to true).
+   *
+   * @param pressure outlet pressure
+   * @param unit pressure unit
+   */
+  public void setOutletPressure(double pressure, String unit) {
+    this.pressureOut = pressure;
+    this.pressureUnit = unit;
+  }
+
+  /**
+   * Enable solving for flow rate from a specified outlet pressure instead of solving for outlet
+   * pressure from a specified flow rate.
+   *
+   * @param solve true to compute flow from the set outlet pressure
+   */
+  public void solveFlowFromOutletPressure(boolean solve) {
+    this.calcpressure = !solve;
+  }
+
+  /**
+   * @return true if the well is set to compute outlet pressure from the inlet stream flowrate.
+   */
+  public boolean isCalculatingOutletPressure() {
+    return calcpressure;
+  }
+
+  /**
    * Use Vogel inflow performance relationship.
    *
    * @param qTest flow rate at test conditions (same unit as stream)

--- a/src/test/java/neqsim/process/equipment/network/WellFlowlineNetworkTest.java
+++ b/src/test/java/neqsim/process/equipment/network/WellFlowlineNetworkTest.java
@@ -1,0 +1,309 @@
+package neqsim.process.equipment.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.pipeline.PipeBeggsAndBrills;
+import neqsim.process.equipment.reservoir.SimpleReservoir;
+import neqsim.process.equipment.reservoir.WellFlow;
+import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemPrEos;
+
+class WellFlowlineNetworkTest {
+
+  private SystemInterface buildGasReservoirFluid() {
+    SystemInterface fluid = new SystemPrEos(303.15, 120.0);
+    fluid.addComponent("water", 2.0);
+    fluid.addComponent("methane", 70.0);
+    fluid.addComponent("n-heptane", 5.0);
+    fluid.setMixingRule(2);
+    fluid.setMultiPhaseCheck(true);
+    return fluid;
+  }
+
+  private SystemInterface buildOilReservoirFluid() {
+    SystemInterface fluid = new SystemPrEos(315.15, 230.0);
+    fluid.addComponent("water", 4.0);
+    fluid.addComponent("methane", 15.0);
+    fluid.addComponent("n-heptane", 32.0);
+    fluid.addComponent("n-dodecane", 18.0);
+    fluid.setMixingRule(2);
+    fluid.setMultiPhaseCheck(true);
+    return fluid;
+  }
+
+  private SimpleReservoir createGasReservoir(ProcessSystem process, String name) {
+    SimpleReservoir reservoir = new SimpleReservoir(name);
+    reservoir.setReservoirFluid(buildGasReservoirFluid(), 7.0e8, 10.0, 300.0);
+    process.add(reservoir);
+    return reservoir;
+  }
+
+  private SimpleReservoir createOilReservoir(ProcessSystem process, String name) {
+    SimpleReservoir reservoir = new SimpleReservoir(name);
+    reservoir.setReservoirFluid(buildOilReservoirFluid(), 6.5e8, 18.0, 320.0);
+    process.add(reservoir);
+    return reservoir;
+  }
+
+  private StreamInterface addGasProducer(SimpleReservoir reservoir, String name, double flowRate) {
+    StreamInterface producer = reservoir.addGasProducer(name + " producer");
+    producer.setFlowRate(flowRate, "MSm3/day");
+    return producer;
+  }
+
+  private StreamInterface addOilProducer(SimpleReservoir reservoir, String name, double flowRate) {
+    StreamInterface producer = reservoir.addOilProducer(name + " producer");
+    producer.setFlowRate(flowRate, "MSm3/day");
+    return producer;
+  }
+
+  @Test
+  void testNetworkWithMultipleManifoldsAndCommonEndpoint() {
+    ProcessSystem process = new ProcessSystem();
+    SimpleReservoir gasReservoir = createGasReservoir(process, "template 1 gas reservoir");
+    SimpleReservoir oilReservoir = createOilReservoir(process, "template 2 oil reservoir");
+
+    StreamInterface branch1 = addGasProducer(gasReservoir, "branch1", 1.1);
+    StreamInterface branch2 = addGasProducer(gasReservoir, "branch2", 1.3);
+    StreamInterface branch3 = addOilProducer(oilReservoir, "branch3", 0.9);
+    StreamInterface branch4 = addOilProducer(oilReservoir, "branch4", 1.2);
+    StreamInterface branch5 = addOilProducer(oilReservoir, "branch5", 0.8);
+
+    WellFlowlineNetwork network = new WellFlowlineNetwork("template network");
+
+    WellFlowlineNetwork.ManifoldNode twoWellManifold =
+        network.createManifold("two-well manifold");
+    WellFlowlineNetwork.ManifoldNode threeWellManifold =
+        network.createManifold("three-well manifold");
+    WellFlowlineNetwork.ManifoldNode centralManifold = network.createManifold("central manifold");
+    PipeBeggsAndBrills commonPipeline = new PipeBeggsAndBrills("common pipeline",
+        centralManifold.getMixer().getOutletStream());
+    commonPipeline.setLength(1200.0);
+    commonPipeline.setDiameter(0.55);
+    commonPipeline.setPipeWallRoughness(4.5e-5);
+    WellFlowlineNetwork.ManifoldNode endManifold = network.addManifold("end manifold", commonPipeline);
+
+    PipeBeggsAndBrills twoToCentral = new PipeBeggsAndBrills("two to central",
+        twoWellManifold.getMixer().getOutletStream());
+    twoToCentral.setLength(600.0);
+    twoToCentral.setDiameter(0.4);
+    twoToCentral.setPipeWallRoughness(4.5e-5);
+    PipeBeggsAndBrills threeToCentral = new PipeBeggsAndBrills("three to central",
+        threeWellManifold.getMixer().getOutletStream());
+    threeToCentral.setLength(550.0);
+    threeToCentral.setDiameter(0.38);
+    threeToCentral.setPipeWallRoughness(4.5e-5);
+
+    network.connectManifolds(twoWellManifold, centralManifold, twoToCentral);
+    network.connectManifolds(threeWellManifold, centralManifold, threeToCentral);
+
+    WellFlow well1 = new WellFlow("well 1");
+    well1.setInletStream(branch1);
+    well1.setWellProductionIndex(5.5e-4);
+    ThrottlingValve choke1 = new ThrottlingValve("choke 1", well1.getOutletStream());
+    choke1.setOutletPressure(70.0, "bara");
+    PipeBeggsAndBrills pipe1 = new PipeBeggsAndBrills("pipe 1", well1.getOutletStream());
+    pipe1.setLength(400.0);
+    pipe1.setDiameter(0.32);
+    pipe1.setPipeWallRoughness(4.5e-5);
+    network.addBranch("branch1", well1, pipe1, choke1, twoWellManifold);
+
+    WellFlow well2 = new WellFlow("well 2");
+    well2.setInletStream(branch2);
+    well2.setWellProductionIndex(5.2e-4);
+    PipeBeggsAndBrills pipe2 = new PipeBeggsAndBrills("pipe 2", well2.getOutletStream());
+    pipe2.setLength(420.0);
+    pipe2.setDiameter(0.34);
+    pipe2.setPipeWallRoughness(4.5e-5);
+    network.addBranch("branch2", well2, pipe2, twoWellManifold);
+
+    WellFlow well3 = new WellFlow("well 3");
+    well3.setInletStream(branch3);
+    well3.setWellProductionIndex(5.8e-4);
+    ThrottlingValve choke3 = new ThrottlingValve("choke 3", well3.getOutletStream());
+    choke3.setOutletPressure(68.0, "bara");
+    PipeBeggsAndBrills pipe3 = new PipeBeggsAndBrills("pipe 3", well3.getOutletStream());
+    pipe3.setLength(450.0);
+    pipe3.setDiameter(0.33);
+    pipe3.setPipeWallRoughness(4.5e-5);
+    network.addBranch("branch3", well3, pipe3, choke3, threeWellManifold);
+
+    WellFlow well4 = new WellFlow("well 4");
+    well4.setInletStream(branch4);
+    well4.setWellProductionIndex(6.0e-4);
+    PipeBeggsAndBrills pipe4 = new PipeBeggsAndBrills("pipe 4", well4.getOutletStream());
+    pipe4.setLength(460.0);
+    pipe4.setDiameter(0.36);
+    pipe4.setPipeWallRoughness(4.5e-5);
+    network.addBranch("branch4", well4, pipe4, threeWellManifold);
+
+    WellFlow well5 = new WellFlow("well 5");
+    well5.setInletStream(branch5);
+    well5.setWellProductionIndex(5.0e-4);
+    PipeBeggsAndBrills pipe5 = new PipeBeggsAndBrills("pipe 5", well5.getOutletStream());
+    pipe5.setLength(430.0);
+    pipe5.setDiameter(0.31);
+    pipe5.setPipeWallRoughness(4.5e-5);
+    network.addBranch("branch5", well5, pipe5, threeWellManifold);
+
+    network.setTargetEndpointPressure(55.0, "bara");
+
+    process.add(network);
+    process.run();
+
+    assertNotNull(network.getArrivalStream());
+
+    double arrivalFlow = network.getArrivalStream().getFlowRate("MSm3/day");
+    double expectedFlow = pipe1.getOutletStream().getFlowRate("MSm3/day")
+        + pipe2.getOutletStream().getFlowRate("MSm3/day")
+        + pipe3.getOutletStream().getFlowRate("MSm3/day")
+        + pipe4.getOutletStream().getFlowRate("MSm3/day")
+        + pipe5.getOutletStream().getFlowRate("MSm3/day");
+    assertEquals(expectedFlow, arrivalFlow, 1e-6);
+
+    double twoManifoldPressure = twoToCentral.getOutletStream().getPressure("bara");
+    double threeManifoldPressure = threeToCentral.getOutletStream().getPressure("bara");
+    double centralPressure = centralManifold.getMixer().getOutletStream().getPressure("bara");
+    double endPressure = endManifold.getMixer().getOutletStream().getPressure("bara");
+
+    assertEquals(twoManifoldPressure, pipe1.getOutletStream().getPressure("bara"), 1e-6);
+    assertEquals(twoManifoldPressure, pipe2.getOutletStream().getPressure("bara"), 1e-6);
+    assertEquals(twoManifoldPressure, choke1.getOutletStream().getPressure("bara"), 1e-6);
+    assertEquals(threeManifoldPressure, pipe3.getOutletStream().getPressure("bara"), 1e-6);
+    assertEquals(threeManifoldPressure, pipe4.getOutletStream().getPressure("bara"), 1e-6);
+    assertEquals(threeManifoldPressure, pipe5.getOutletStream().getPressure("bara"), 1e-6);
+    assertEquals(threeManifoldPressure, choke3.getOutletStream().getPressure("bara"), 1e-6);
+    assertEquals(centralPressure, twoToCentral.getOutletStream().getPressure("bara"), 1e-6);
+    assertEquals(centralPressure, threeToCentral.getOutletStream().getPressure("bara"), 1e-6);
+    assertEquals(endPressure, commonPipeline.getOutletStream().getPressure("bara"), 1e-6);
+    assertEquals(55.0, endPressure, 1e-2);
+    assertEquals(55.0, network.getTerminalManifoldPressure("bara"), 1e-6);
+    assertEquals(endPressure, network.getArrivalStream().getPressure("bara"), 1e-6);
+    assertEquals(5, network.getManifolds().size());
+  }
+
+  @Test
+  void chokeValvePositionChangesBranchFlow() {
+    ProcessSystem process = new ProcessSystem();
+    SimpleReservoir reservoir = createGasReservoir(process, "gas reservoir");
+    StreamInterface producer = addGasProducer(reservoir, "gas", 1.0);
+
+    WellFlowlineNetwork network = new WellFlowlineNetwork("choke test network");
+
+    WellFlow well = new WellFlow("well with choke");
+    well.setInletStream(producer);
+    well.setWellProductionIndex(5.0e-4);
+
+    ThrottlingValve choke = new ThrottlingValve("branch choke", well.getOutletStream());
+    choke.setKv(15.0);
+    choke.setPercentValveOpening(100.0);
+
+    PipeBeggsAndBrills pipeline = new PipeBeggsAndBrills("branch pipeline",
+        choke.getOutletStream());
+    pipeline.setLength(300.0);
+    pipeline.setDiameter(0.32);
+    pipeline.setPipeWallRoughness(4.5e-5);
+
+    network.addBranch("gas branch", well, pipeline, choke, network.getManifolds().get(0));
+
+    process.add(network);
+    process.run();
+
+    double wideOpenFlow = pipeline.getOutletStream().getFlowRate("MSm3/day");
+
+    choke.setPercentValveOpening(40.0);
+    process.run();
+
+    double chokedFlow = pipeline.getOutletStream().getFlowRate("MSm3/day");
+
+    assertTrue(chokedFlow < wideOpenFlow);
+  }
+
+  @Test
+  void optimizeWellChokesForOilDelivery() {
+    ProcessSystem process = new ProcessSystem();
+    SimpleReservoir oilReservoir = createOilReservoir(process, "shared oil reservoir");
+
+    StreamInterface producer1 = addOilProducer(oilReservoir, "oil branch 1", 1.5);
+    StreamInterface producer2 = addOilProducer(oilReservoir, "oil branch 2", 1.2);
+
+    WellFlowlineNetwork network = new WellFlowlineNetwork("oil optimization network");
+
+    WellFlow well1 = new WellFlow("oil well 1");
+    well1.setInletStream(producer1);
+    well1.setWellProductionIndex(6.0e-4);
+    ThrottlingValve choke1 = new ThrottlingValve("oil choke 1", well1.getOutletStream());
+    choke1.setKv(18.0);
+    choke1.setPercentValveOpening(60.0);
+    PipeBeggsAndBrills pipe1 = new PipeBeggsAndBrills("oil pipe 1", choke1.getOutletStream());
+    pipe1.setLength(450.0);
+    pipe1.setDiameter(0.34);
+    pipe1.setPipeWallRoughness(4.5e-5);
+    network.addBranch("oil branch 1", well1, pipe1, choke1, network.getManifolds().get(0));
+
+    WellFlow well2 = new WellFlow("oil well 2");
+    well2.setInletStream(producer2);
+    well2.setWellProductionIndex(5.5e-4);
+    ThrottlingValve choke2 = new ThrottlingValve("oil choke 2", well2.getOutletStream());
+    choke2.setKv(16.0);
+    choke2.setPercentValveOpening(60.0);
+    PipeBeggsAndBrills pipe2 = new PipeBeggsAndBrills("oil pipe 2", choke2.getOutletStream());
+    pipe2.setLength(430.0);
+    pipe2.setDiameter(0.32);
+    pipe2.setPipeWallRoughness(4.5e-5);
+    network.addBranch("oil branch 2", well2, pipe2, choke2, network.getManifolds().get(0));
+
+    PipeBeggsAndBrills exportLine = new PipeBeggsAndBrills("export line",
+        network.getArrivalMixer().getOutletStream());
+    exportLine.setLength(1000.0);
+    exportLine.setDiameter(0.5);
+    exportLine.setPipeWallRoughness(4.5e-5);
+    network.setFacilityPipeline(exportLine);
+
+    network.setTargetEndpointPressure(60.0, "bara");
+    process.add(network);
+
+    double[] openings = new double[] {40.0, 70.0, 100.0};
+    double bestOilRate = -1.0;
+    double bestChoke1 = 0.0;
+    double bestChoke2 = 0.0;
+
+    for (double opening1 : openings) {
+      for (double opening2 : openings) {
+        choke1.setPercentValveOpening(opening1);
+        choke2.setPercentValveOpening(opening2);
+        process.run();
+
+        double oilRate = network.getArrivalStream().getFluid()
+            .getComponent("n-dodecane").getFlowRate("kg/hr");
+
+        if (oilRate > bestOilRate) {
+          bestOilRate = oilRate;
+          bestChoke1 = opening1;
+          bestChoke2 = opening2;
+        }
+      }
+    }
+
+    process.run();
+
+    double throttledOilRate = network.getArrivalStream().getFluid()
+        .getComponent("n-dodecane").getFlowRate("kg/hr");
+
+    choke1.setPercentValveOpening(30.0);
+    choke2.setPercentValveOpening(30.0);
+    process.run();
+    double tightOilRate = network.getArrivalStream().getFluid().getComponent("n-dodecane")
+        .getFlowRate("kg/hr");
+
+    assertTrue(throttledOilRate > tightOilRate);
+    assertEquals(100.0, bestChoke1, 1e-6);
+    assertEquals(100.0, bestChoke2, 1e-6);
+    assertTrue(bestOilRate >= throttledOilRate);
+  }
+}


### PR DESCRIPTION
## Summary
- add an integration test showing choke-position optimization for maximizing oil arrival from two wells feeding a shared manifold and export line

## Testing
- Not run (network dependency downloads not attempted in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921984e2f04832d99643b9132ce2c2f)