### PR TITLE
Validate null handling in physical property type lookup

### DIFF
--- a/src/main/java/neqsim/physicalproperties/PhysicalPropertyType.java
+++ b/src/main/java/neqsim/physicalproperties/PhysicalPropertyType.java
@@ -21,6 +21,11 @@ public enum PhysicalPropertyType {
    * @return PhysicalPropertyType object
    */
   public static PhysicalPropertyType byName(String name) {
+    if (name == null || name.isBlank()) {
+      throw new RuntimeException(new InvalidInputException("PhysicalPropertyType", "byName",
+          "name", "cannot be null or empty."));
+    }
+
     // suport old names
     name = name.toUpperCase();
     if (name.equals("DENSITY")) {

--- a/src/test/java/neqsim/physicalproperties/PhysicalPropertyTypeTest.java
+++ b/src/test/java/neqsim/physicalproperties/PhysicalPropertyTypeTest.java
@@ -1,7 +1,9 @@
 package neqsim.physicalproperties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
+import neqsim.util.exception.InvalidInputException;
 import neqsim.thermo.phase.PhaseType;
 import neqsim.thermo.system.SystemInterface;
 import neqsim.thermo.system.SystemPrEos;
@@ -24,6 +26,10 @@ public class PhysicalPropertyTypeTest {
     assertEquals(PhysicalPropertyType.byName("conductivity"),
         PhysicalPropertyType.THERMAL_CONDUCTIVITY);
     assertEquals(PhysicalPropertyType.byName("viscosity"), PhysicalPropertyType.DYNAMIC_VISCOSITY);
+
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> PhysicalPropertyType.byName(null), "null input should be rejected");
+    assertEquals(InvalidInputException.class, ex.getCause().getClass());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- guard PhysicalPropertyType.byName against null or blank names with a descriptive InvalidInputException
- add a unit test to verify null inputs are rejected instead of triggering a NullPointerException

## Testing
- mvn -DskipITs -DskipSlowTests -Dtest=PhysicalPropertyTypeTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f9ba3d0c832dbeb26265b541ab9a)