### PR TITLE
Fix VirtualStream solved status propagation

### DIFF
--- a/src/main/java/neqsim/process/equipment/stream/VirtualStream.java
+++ b/src/main/java/neqsim/process/equipment/stream/VirtualStream.java
@@ -143,6 +143,8 @@ public class VirtualStream extends ProcessEquipmentBaseClass {
       outStream.getFluid().setMolarComposition(composition);
     }
     outStream.run(id);
+
+    isSolved = outStream.solved();
   }
 
   /**
@@ -159,7 +161,6 @@ public class VirtualStream extends ProcessEquipmentBaseClass {
   /** {@inheritDoc} */
   @Override
   public boolean solved() {
-    // TODO Auto-generated method stub
-    return false;
+    return outStream != null ? outStream.solved() : super.solved();
   }
 }

--- a/src/test/java/neqsim/process/equipment/stream/VirtualStreamTest.java
+++ b/src/test/java/neqsim/process/equipment/stream/VirtualStreamTest.java
@@ -1,6 +1,7 @@
 package neqsim.process.equipment.stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import neqsim.process.processmodel.ProcessSystem;
@@ -72,5 +73,11 @@ public class VirtualStreamTest {
     virtStream.setTemperature(22.0, "C");
     virtStream.run();
     assertEquals(22.0, virtStream.getOutStream().getTemperature("C"), 1e-6);
+  }
+
+  @Test
+  void testSolvedFlag() {
+    virtStream.run();
+    assertTrue(virtStream.solved());
   }
 }


### PR DESCRIPTION
## Summary
- propagate the solved state from the VirtualStream's generated out stream
- ensure the solved check uses the calculated stream when present
- add a regression test covering the solved flag after running a virtual stream

## Testing
- mvn -q -Dtest=VirtualStreamTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ffa71b08832db063fbea1745aefc)