### PR TITLE
Replace String isBlank usage for Java 8 compatibility

### DIFF
--- a/src/main/java/neqsim/physicalproperties/PhysicalPropertyType.java
+++ b/src/main/java/neqsim/physicalproperties/PhysicalPropertyType.java
@@ -21,7 +21,7 @@ public enum PhysicalPropertyType {
    * @return PhysicalPropertyType object
    */
   public static PhysicalPropertyType byName(String name) {
-    if (name == null || name.isBlank()) {
+    if (name == null || name.trim().isEmpty()) {
       throw new RuntimeException(new InvalidInputException("PhysicalPropertyType", "byName",
           "name", "cannot be null or empty."));
     }


### PR DESCRIPTION
## Summary
- replace String.isBlank usage with trim().isEmpty() in PhysicalPropertyType to support Java 8 compatibility

## Testing
- ./mvnw -q -DskipTests compile *(fails: network is unreachable when downloading Maven wrapper dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922055ae78c832db4a92ad8d73d39c3)