### PR TITLE
Reduce logging noise when TVfractionFlash encounters invalid state

### DIFF
--- a/src/main/java/neqsim/thermodynamicoperations/flashops/TVfractionFlash.java
+++ b/src/main/java/neqsim/thermodynamicoperations/flashops/TVfractionFlash.java
@@ -150,10 +150,6 @@ public class TVfractionFlash extends Flash {
     tpFlash.run();
 
     if (stateHasUncountableNumbers(system)) {
-      if (!reportedUncountableState) {
-        logger.error("Solution contains uncountable numbers");
-        reportedUncountableState = true;
-      }
       system.setPressure(oldPres);
     }
 
@@ -217,15 +213,19 @@ public class TVfractionFlash extends Flash {
   }
 
   private void reportNonFinite(String field, int phaseIndex, String componentName, double value) {
-    if (!reportedUncountableState) {
-      if (componentName != null) {
-        logger.error(
-            "Solution contains uncountable numbers: {} for component '{}' in phase {} (value={})",
-            field, componentName, phaseIndex, value);
-      } else {
-        logger.error("Solution contains uncountable numbers: {} in phase {} (value={})", field,
-            phaseIndex, value);
-      }
+    if (reportedUncountableState) {
+      return;
+    }
+
+    reportedUncountableState = true;
+
+    if (componentName != null) {
+      logger.error(
+          "Solution contains uncountable numbers: {} for component '{}' in phase {} (value={})",
+          field, componentName, phaseIndex, value);
+    } else {
+      logger.error("Solution contains uncountable numbers: {} in phase {} (value={})", field,
+          phaseIndex, value);
     }
   }
 }


### PR DESCRIPTION
## Summary
- guard uncountable-number logging in TVfractionFlash so it only reports the first occurrence per instance
- remove duplicate summary logging while keeping detailed context for the first invalid value

## Testing
- not run (compilation was interrupted)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69220a0da684832daf106ac8c4837087)