### PR TITLE
Support alias names in Gibbs reactor database

### DIFF
--- a/src/main/java/neqsim/process/equipment/reactor/GibbsReactor.java
+++ b/src/main/java/neqsim/process/equipment/reactor/GibbsReactor.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import org.ejml.simple.SimpleMatrix;
 import neqsim.process.equipment.TwoPortEquipment;
 import neqsim.process.equipment.stream.StreamInterface;
+import neqsim.thermo.component.ComponentInterface;
 import neqsim.thermo.system.SystemInterface;
 
 /**
@@ -824,8 +825,24 @@ public class GibbsReactor extends TwoPortEquipment {
       }
       scanner.close();
       logger.info("Loaded " + gibbsDatabase.size() + " components from Gibbs database");
+
+      addAliasMappings();
     } catch (Exception e) {
       logger.error("Error loading Gibbs database: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Populate {@link #componentMap} with common component aliases so fluids imported with shorthand
+   * names (e.g. Eclipse E300) are resolved to Gibbs database entries.
+   */
+  private void addAliasMappings() {
+    Map<String, String> aliasMap = ComponentInterface.getComponentNameMap();
+    for (Map.Entry<String, String> entry : aliasMap.entrySet()) {
+      GibbsComponent component = componentMap.get(entry.getValue().toLowerCase());
+      if (component != null) {
+        componentMap.putIfAbsent(entry.getKey().toLowerCase(), component);
+      }
     }
   }
 

--- a/src/test/java/neqsim/process/equipment/reactor/GibbsReactorTest.java
+++ b/src/test/java/neqsim/process/equipment/reactor/GibbsReactorTest.java
@@ -1,5 +1,6 @@
 package neqsim.process.equipment.reactor;
 
+import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import neqsim.process.equipment.stream.Stream;
@@ -52,6 +53,29 @@ public class GibbsReactorTest {
     // Assert that mass balance is converged
     Assertions.assertTrue(reactor.getMassBalanceConverged(),
         "Mass balance should be converged for TBPfraction test");
+  }
+
+  /**
+   * Verify that shorthand component names (e.g. iC4) are resolved to Gibbs database entries to
+   * support Eclipse E300 fluids in reactors.
+   */
+  @Test
+  public void testAliasComponentsResolvedInGibbsDatabase() {
+    SystemInterface system = new SystemSrkEos(298.15, 1.0);
+    system.addComponent("iC4", 0.1);
+    system.addComponent("C1", 0.9);
+    system.addComponent("oxygen", 0.5);
+    system.addComponent("nitrogen", 1.9);
+    system.createDatabase(true);
+    system.setMixingRule(2);
+
+    Stream inletStream = new Stream("Alias inlet", system);
+
+    GibbsReactor reactor = new GibbsReactor("Alias reactor", inletStream);
+    reactor.setUseAllDatabaseSpecies(false);
+    reactor.setEnergyMode(GibbsReactor.EnergyMode.ADIABATIC);
+
+    Assertions.assertDoesNotThrow(() -> reactor.run(UUID.randomUUID()));
   }
 
   /**


### PR DESCRIPTION
## Summary
- add alias mappings so Gibbs reactor database recognizes Eclipse E300 shorthand component names
- add regression test covering iC4 alias handling in Gibbs reactor

## Testing
- mvn -Dtest=neqsim.process.equipment.reactor.GibbsReactorTest#testAliasComponentsResolvedInGibbsDatabase test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69222013c610832da58292e83649702f)