### PR TITLE
Add weight-based composition retrieval

### DIFF
--- a/src/main/java/neqsim/thermo/system/SystemInterface.java
+++ b/src/main/java/neqsim/thermo/system/SystemInterface.java
@@ -1144,6 +1144,15 @@ public interface SystemInterface extends Cloneable, java.io.Serializable {
   public double[] getMolarComposition();
 
   /**
+   * <p>
+   * Returns the overall composition vector in unit mass fraction.
+   * </p>
+   *
+   * @return an array of type double
+   */
+  public double[] getWeightBasedComposition();
+
+  /**
    * Get molar mass of system.
    *
    * @return molar mass in unit kg/mol

--- a/src/main/java/neqsim/thermo/system/SystemThermo.java
+++ b/src/main/java/neqsim/thermo/system/SystemThermo.java
@@ -2840,6 +2840,26 @@ public abstract class SystemThermo implements SystemInterface {
 
   /** {@inheritDoc} */
   @Override
+  public double[] getWeightBasedComposition() {
+    PhaseInterface phase = this.getPhase(0);
+    double[] comp = new double[phase.getNumberOfComponents()];
+
+    double totalMass = 0.0;
+    for (int compNumb = 0; compNumb < numberOfComponents; compNumb++) {
+      totalMass +=
+          phase.getComponent(compNumb).getz() * phase.getComponent(compNumb).getMolarMass();
+    }
+
+    for (int compNumb = 0; compNumb < numberOfComponents; compNumb++) {
+      comp[compNumb] =
+          phase.getComponent(compNumb).getz() * phase.getComponent(compNumb).getMolarMass()
+              / totalMass;
+    }
+    return comp;
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public double getMolarMass() {
     double tempVar = 0;
     for (int i = 0; i < phaseArray[0].getNumberOfComponents(); i++) {

--- a/src/test/java/neqsim/thermo/system/SystemThermoSetMolarCompositionTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemThermoSetMolarCompositionTest.java
@@ -1,6 +1,7 @@
 package neqsim.thermo.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.Arrays;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -101,5 +102,25 @@ public class SystemThermoSetMolarCompositionTest extends neqsim.NeqSimTest {
     double flowRate = sys.getFlowRate("kg/hr");
 
     assertEquals(876223.6458342039, flowRate, 1e-3);
+  }
+
+  @Test
+  void testWeightBasedComposition() {
+    SystemInterface weightSystem = new SystemSrkEos(298.0, 50.0);
+    weightSystem.addComponent("methane", 1.0);
+    weightSystem.addComponent("ethane", 1.0);
+    weightSystem.setMolarComposition(new double[] {0.25, 0.75});
+
+    double[] weightComposition = weightSystem.getWeightBasedComposition();
+
+    double mixtureMolarMass = weightSystem.getMolarMass();
+    double expectedFirst = weightSystem.getPhase(0).getComponent(0).getMolarMass() * 0.25
+        / mixtureMolarMass;
+    double expectedSecond = weightSystem.getPhase(0).getComponent(1).getMolarMass() * 0.75
+        / mixtureMolarMass;
+
+    assertEquals(expectedFirst, weightComposition[0]);
+    assertEquals(expectedSecond, weightComposition[1]);
+    assertEquals(1.0, Arrays.stream(weightComposition).sum(), 1e-12);
   }
 }


### PR DESCRIPTION
## Summary
- add a weight-based composition accessor to fluid systems
- compute system mass fractions using overall composition and molar masses
- add a regression test verifying the mass-based composition calculation

## Testing
- mvn -q -Dtest=SystemThermoSetMolarCompositionTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692301adec40832d8b9ddf4d7ea3a3f8)