### PR TITLE
Add thermodynamics documentation set

### DIFF
--- a/docs/thermo/README.md
+++ b/docs/thermo/README.md
@@ -1,0 +1,12 @@
+# Thermodynamic Documentation Set
+
+This folder collects topic-specific documentation for using NeqSim's thermodynamic, PVT, and physical property capabilities. Each page is intended to be self-contained while pointing to related guides so you can jump directly to the workflows you need.
+
+## Contents
+- [Mathematical Models](mathematical_models.md): Equations of state, activity-coefficient formulations, and transport correlations available in NeqSim.
+- [Thermodynamic Workflows](thermodynamic_workflows.md): How to set up systems, select models, and perform common equilibrium calculations.
+- [PVT and Fluid Characterization](pvt_fluid_characterization.md): Building realistic fluid descriptions, including heavy-end handling and lab-data reconciliation.
+- [Thermodynamic Operations](thermodynamic_operations.md): Flash calculations, phase envelopes, and other process-centric operations.
+- [Physical Properties](physical_properties.md): Density, viscosity, surface tension, and transport-property calculations.
+
+Each document favors short, reproducible code snippets using the Java API so the same ideas transfer to other supported languages (Python/Matlab) with minor syntax changes.

--- a/docs/thermo/mathematical_models.md
+++ b/docs/thermo/mathematical_models.md
@@ -1,0 +1,40 @@
+# Mathematical Models in NeqSim
+
+NeqSim bundles several thermodynamic and transport models so you can switch between correlations without rewriting system setup code. The sections below summarize the most commonly used options and when to consider them.
+
+## Equations of State (EoS)
+- **Peng–Robinson (PR) family**: Standard PR (`SystemPrEos`), volume-corrected variants, and tuned versions such as the Søreide–Whitson model for sour service. Suitable for general gas/condensate and light-oil systems.
+- **Soave–Redlich–Kwong (SRK) family**: Core SRK (`SystemSrkEos`), SRK-Twu, and CPA-SRK for associating fluids such as water and glycols.
+- **Cubic-Plus-Association (CPA)**: Adds association terms to SRK to represent hydrogen bonding while keeping cubic EoS performance.
+- **Activity-coefficient hybrids**: Huron–Vidal and Wong–Sandler mixing rules combine cubic EoS with excess-Gibbs models for improved liquid-phase behavior.
+
+### Selecting an EoS
+```java
+SystemInterface fluid = new SystemSrkEos(298.15, 50.0);
+fluid.addComponent("methane", 0.9);
+fluid.addComponent("n-heptane", 0.1);
+fluid.setMixingRule(2); // 2 = Huron–Vidal; use 1 for classical van der Waals
+```
+Use `SystemSrkCPAstatoil` or `SystemSrkCPAs` when hydrogen bonding is important, and prefer PR variants for high-pressure gas processing.
+
+## Activity-Coefficient Models
+NeqSim provides NRTL/UNIQUAC/UNIFAC variants for non-ideal liquid mixtures. They can be used directly for gamma-phi flashes or combined with cubic EoS via Wong–Sandler mixing rules.
+
+```java
+SystemInterface fluid = new SystemFurstElectrolyteEos(298.15, 1.0);
+fluid.addComponent("water", 1.0);
+fluid.addComponent("ethanol", 1.0);
+fluid.setMixingRule(4); // enables Wong–Sandler (NRTL) coupling
+```
+Load binary-interaction parameters via `mixingRuleName` or by reading custom datasets to align with lab data.
+
+## Hydrate and Solid Models
+For hydrate prediction, enable `hydrateCheck(true)` and select a hydrate model (`CPA`-based or classical van der Waals–Platteeuw) depending on accuracy and speed requirements. Wax precipitation can be modeled using solid-phase enabled systems (e.g., PR with solid checks) and tuned heavy-end characterizations.
+
+## Transport and Physical Property Correlations
+- **Viscosity**: Low-pressure correlations (e.g., Chung) and high-pressure gas correlations plus heavy-oil extensions. CPA fluids can include association corrections for viscosity.
+- **Thermal conductivity**: Dense-phase corrections layered on dilute-gas references.
+- **Surface tension**: Parachor correlations tied to component critical properties.
+- **Diffusion and mass transfer**: Fickian diffusion coefficients and film models for unit operations.
+
+Choose property packages that match the flow regime: cubic EoS with corresponding-state transport for gas processing, CPA with association corrections for aqueous systems, and heavy-oil tuned correlations for late-life reservoirs.

--- a/docs/thermo/physical_properties.md
+++ b/docs/thermo/physical_properties.md
@@ -1,0 +1,30 @@
+# Physical Property Calculations
+
+NeqSim computes phase and mixture properties after thermodynamic initialization. This guide highlights the most used methods and how to choose appropriate models.
+
+## Density and Compressibility
+- Call `fluid.initPhysicalProperties()` or `fluid.initProperties()` after a flash to populate density (`getDensity()`) and compressibility (`getZ()`).
+- Apply volume-shifted PR/SRK models when liquid density underpredicts lab data.
+
+## Viscosity
+- `getViscosity()` on a phase returns dynamic viscosity. Correlations switch automatically based on system type:
+  - Corresponding-states for gases and light condensates.
+  - Heavy-oil extensions when TBP fractions or high molar masses are present.
+  - Association-corrected viscosity for CPA systems.
+- Use `setMixingRule(7)` or CPA fluids when hydrogen bonding impacts rheology (water, glycols).
+
+## Thermal Conductivity and Heat Capacity
+- `getThermalConductivity()` provides phase thermal conductivity using dense-gas corrections.
+- `getCp()` and `getEnthalpy()` support energy balances. Reinitialize (`init(3)`) if temperature changes substantially between calls.
+
+## Surface and Interfacial Tension
+- `getInterfacialTension(phase1, phase2)` calculates tension between phases (e.g., gas-oil, gas-water) using parachor correlations tied to the active EOS.
+- Ensure both phases are present after a flash; otherwise, perform a two-phase flash at representative separator conditions first.
+
+## Diffusion and Mass Transfer
+- `getDiffusionCoefficient()` is available on phases for estimating film and molecular diffusion coefficients.
+- In unit operations, enable mass-transfer calculations to access local Sherwood correlations and film models.
+
+## Numerical Tips
+- Always flash (`TPflash`, `PHflash`, etc.) before requesting properties; raw composition-only systems do not hold valid properties.
+- When looping over many states, reuse fluids and call `initPhysicalProperties()` after each state change to refresh transport properties without repeating equilibrium calculations.

--- a/docs/thermo/pvt_fluid_characterization.md
+++ b/docs/thermo/pvt_fluid_characterization.md
@@ -1,0 +1,39 @@
+# PVT and Fluid Characterization
+
+Accurate phase behavior predictions start with a realistic fluid description. NeqSim supports full compositional models, TBP cuts, and black-oil style pseudo-components.
+
+## Building Compositions
+1. **Known components**: Add pure components directly using critical-property data from the internal database.
+2. **Plus fractions (C7+)**: Use `addPlusFraction(name, moles, molarMass, density)` when only overall heavy fraction data are available.
+3. **TBP/assay data**: Use `addTBPfraction(name, moles, density, molarMass)` to preserve multiple heavy cuts with their own boiling ranges.
+
+```java
+SystemInterface oil = new SystemSrkEos(323.15, 150.0);
+oil.createDatabase(true);
+oil.addComponent("nitrogen", 0.01);
+oil.addComponent("methane", 0.60);
+oil.addTBPfraction("C7", 0.08, 0.73, 7.5);
+oil.addTBPfraction("C10", 0.10, 0.80, 10.5);
+oil.addPlusFraction("C20+", 0.21, 0.92, 22.0);
+oil.setMixingRule(2);
+```
+
+## Tuning and Regression
+- **Binary interaction parameters (kij)**: Adjust kij tables (`setBinaryInteractionParameter`) to match dew/bubble points.
+- **Volume shift/critical-point matching**: Enable volume corrections on PR/SRK fluids to improve density fits.
+- **Plus-fraction splitting**: Use `splitTBPfraction` to subdivide heavy cuts using predefined distillation curves.
+- **Viscosity tuning**: Adjust heavy-end Watson K or user-defined viscosity correlations when matching lab rheology.
+
+## PVT Reports
+After running `ThermodynamicOperations.TPflash()`, collect standard PVT outputs:
+```java
+oil.initProperties();
+System.out.println("Bo at separator: " + oil.getPhase("oil").getVolume() / oil.getTotalNumberOfMoles());
+System.out.println("GOR at separator: " + oil.getPhase("gas").getNumberOfMoles()/oil.getPhase("oil").getNumberOfMoles());
+```
+For multi-stage separators, clone the fluid after each flash and continue flashing at downstream conditions.
+
+## Data Management
+- Store compositions and tuned parameters as JSON using `toJson()` for reproducible studies.
+- Use `addFluid(existingSystem)` to combine live-oil and gas-cap fluids or to merge lab and model data sets.
+- When integrating with black-oil simulators, export pseudo-component properties (MW, density, Z-factor) for each stage.

--- a/docs/thermo/thermodynamic_operations.md
+++ b/docs/thermo/thermodynamic_operations.md
@@ -1,0 +1,35 @@
+# Thermodynamic Operations
+
+Thermodynamic operations execute equilibrium and property tasks using a configured fluid. Most workflows create a `ThermodynamicOperations` object once and reuse it for multiple calls.
+
+## Flash Calculations
+- **`TPflash()`**: Calculates phase split at specified temperature and pressure. Run `initProperties()` afterward for density/viscosity.
+- **`PHflash(P, H)` and `PSflash(P, S)`**: Solve for temperature/phase split given enthalpy or entropy targets—useful for compressors and turbines.
+- **`TVflash(T, V)`**: Volume-constrained flash for fixed-volume cells.
+- **`UVflash(U, V)`**: Energy- and volume-constrained flash for transient simulations.
+
+```java
+ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
+ops.TPflash();
+double vaporFraction = fluid.getBeta();
+```
+
+## Phase Envelopes
+- **PT envelope**: `ops.calcPTphaseEnvelope()` fills critical point, cricondenbar, cricondentherm, and two-phase boundary.
+- **Hydrate curves**: Enable `hydrateCheck(true)` before calling `ops.hydrateFormationTemperature(pressure)`.
+- **Wax/solid envelopes**: Use a solid-enabled system and call `ops.calcSolidFormationTemperature()`.
+
+## Property Routines
+After flashes, properties are available on each phase:
+- `getDensity()` or `getNumberOfMoles()` for molar/volume properties.
+- `getEnthalpy()`, `getEntropy()`, and `getCp()` for energy balances.
+- `getViscosity()`, `getThermalConductivity()`, and `getInterfacialTension()` for transport analyses.
+
+## Electrolytes and Reactions
+- **Electrolytes**: Build systems such as `SystemFurstElectrolyteEos` or `SystemElectrolyteCPAstatoil`, add salts/acids, and enable charge balance. Use `ops.electrolyteFlash()` for salt precipitation studies.
+- **Chemical reactions**: Define reactions with stoichiometry and equilibrium constants, then call `ops.calcChemicalEquilibrium()` to couple them into flashes.
+
+## Best Practices
+- Always reinitialize (`fluid.init(3)`) after changing temperature, pressure, or composition significantly.
+- Reuse the same `ThermodynamicOperations` instance when sweeping conditions to avoid rebuilding internal caches.
+- For performance-sensitive loops, pre-allocate fluids and avoid repeated parsing of the component database.

--- a/docs/thermo/thermodynamic_workflows.md
+++ b/docs/thermo/thermodynamic_workflows.md
@@ -1,0 +1,53 @@
+# Thermodynamic Workflows
+
+Use these recipes to configure fluids and run equilibrium calculations with NeqSim. The Java snippets mirror the workflow used in other language bindings.
+
+## 1. Build a Fluid
+```java
+SystemInterface fluid = new SystemPrEos(313.15, 80.0);
+fluid.addComponent("methane", 0.85);
+fluid.addComponent("ethane", 0.05);
+fluid.addTBPfraction("C7+", 0.10, 0.45, 8.0); // name, moles, density [g/cc], MW
+fluid.createDatabase(true); // enable access to component data
+fluid.setMixingRule(1); // classical van der Waals mixing rule
+fluid.init(0);
+```
+
+Tips:
+- Always call `createDatabase(true)` before adding TBP fractions so critical properties and acentric factors are filled automatically.
+- Use `addPlusFraction` for simpler heavy-end inputs, or `addFluid` to merge two existing systems.
+
+## 2. Choose a Model and Mixing Rule
+- `setMixingRule(1)`: classical quadratic kij.
+- `setMixingRule(2)`: Huron–Vidal (gamma-phi) coupling.
+- `setMixingRule(4)`: Wong–Sandler (NRTL-based) coupling.
+- `setMixingRule(7)`: Simplified CPA cross-association rules.
+
+For lean gas, start with PR and kij from correlations; for rich liquids or polar systems, move to SRK-Twu + Huron–Vidal or CPA-SRK.
+
+## 3. Run Thermodynamic Operations
+Instantiate `ThermodynamicOperations` with the configured fluid to access flash and envelope tools:
+```java
+ThermodynamicOperations ops = new ThermodynamicOperations(fluid);
+ops.TPflash();
+fluid.initProperties();
+System.out.println("Vapor fraction: " + fluid.getPhaseFraction(0));
+```
+Common operations include:
+- `PSflash(pressure, entropy)`, `PHflash(pressure, enthalpy)` for process simulators.
+- `dewPointTemperature(pressure)` and `bubblePointPressure(temperature)` for PVT lab matches.
+- `calcPTphaseEnvelope()` and `calcPseudocriticalTemperature()` for compositional screening.
+
+## 4. Save and Reuse States
+Export an EOS state to JSON or clone fluids when sweeping conditions:
+```java
+SystemInterface clone = fluid.clone();
+clone.setTemperature(280.0);
+clone.setPressure(10.0);
+new ThermodynamicOperations(clone).TPflash();
+```
+
+## 5. Debugging and Validation
+- Call `display()` on the fluid to dump compositions, kij values, and phase properties.
+- Use `calcChemicalEquilibrium()` after setting reaction stoichiometry to couple reactions into flashes.
+- Compare `getMolarMass()` and `getZ()` against lab PVT data to verify characterization accuracy.


### PR DESCRIPTION
## Summary
- add a thermodynamics documentation folder that indexes new topic guides
- document available mathematical models and common thermodynamic workflows
- add focused guides for PVT characterization, operations, and physical property calculations

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246be69fd8832da31c551d12b7d0d1)