### PR TITLE
Add mass balance reports for single process systems

### DIFF
--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -1253,6 +1253,81 @@ public class ProcessSystem extends SimulationBaseClass {
   }
 
   /**
+   * Get a formatted mass balance report for this process system.
+   *
+   * @param unit unit for mass flow rate (e.g., "kg/sec", "kg/hr", "mole/sec")
+   * @return a formatted string report with mass balance results
+   */
+  public String getMassBalanceReport(String unit) {
+    StringBuilder report = new StringBuilder();
+    report.append("Process: ").append(getName()).append("\n");
+    report.append(String.format("%0" + 60 + "d", 0).replace('0', '=')).append("\n");
+
+    Map<String, MassBalanceResult> results = checkMassBalance(unit);
+    if (results.isEmpty()) {
+      report.append("No unit operations found.\n");
+    } else {
+      for (Map.Entry<String, MassBalanceResult> entry : results.entrySet()) {
+        report.append(String.format("  %-30s: %s\n", entry.getKey(), entry.getValue().toString()));
+      }
+    }
+    return report.toString();
+  }
+
+  /**
+   * Get a formatted mass balance report for this process system using kg/sec.
+   *
+   * @return a formatted string report with mass balance results
+   */
+  public String getMassBalanceReport() {
+    return getMassBalanceReport("kg/sec");
+  }
+
+  /**
+   * Get a formatted report of failed mass balance checks for this process system.
+   *
+   * @param unit unit for mass flow rate (e.g., "kg/sec", "kg/hr", "mole/sec")
+   * @param percentThreshold percentage error threshold
+   * @return a formatted string report with failed unit operations
+   */
+  public String getFailedMassBalanceReport(String unit, double percentThreshold) {
+    StringBuilder report = new StringBuilder();
+    Map<String, MassBalanceResult> failedResults = getFailedMassBalance(unit, percentThreshold);
+
+    if (failedResults.isEmpty()) {
+      report.append("All unit operations passed mass balance check.\n");
+    } else {
+      report.append("Process: ").append(getName()).append("\n");
+      report.append(String.format("%0" + 60 + "d", 0).replace('0', '=')).append("\n");
+      for (Map.Entry<String, MassBalanceResult> entry : failedResults.entrySet()) {
+        report.append(String.format("  %-30s: %s\n", entry.getKey(), entry.getValue().toString()));
+      }
+    }
+    return report.toString();
+  }
+
+  /**
+   * Get a formatted report of failed mass balance checks for this process system using kg/sec and
+   * default threshold.
+   *
+   * @return a formatted string report with failed unit operations
+   */
+  public String getFailedMassBalanceReport() {
+    return getFailedMassBalanceReport("kg/sec", massBalanceErrorThreshold);
+  }
+
+  /**
+   * Get a formatted report of failed mass balance checks for this process system using specified
+   * threshold.
+   *
+   * @param percentThreshold percentage error threshold
+   * @return a formatted string report with failed unit operations in kg/sec
+   */
+  public String getFailedMassBalanceReport(double percentThreshold) {
+    return getFailedMassBalanceReport("kg/sec", percentThreshold);
+  }
+
+  /**
    * Set the default mass balance error threshold for this process system.
    *
    * @param percentThreshold percentage error threshold (e.g., 0.1 for 0.1%)

--- a/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessSystemTest.java
@@ -1233,6 +1233,34 @@ public class ProcessSystemTest extends neqsim.NeqSimTest {
   }
 
   @Test
+  public void testMassBalanceReportGeneration() {
+    neqsim.thermo.system.SystemInterface fluid1 =
+        new neqsim.thermo.system.SystemSrkEos(298.15, 10.0);
+    fluid1.addComponent("methane", 1.0);
+    fluid1.setMixingRule("classic");
+
+    ProcessSystem process = new ProcessSystem();
+
+    Stream stream1 = new Stream("Stream1", fluid1);
+    stream1.setFlowRate(100.0, "kg/hr");
+    stream1.setTemperature(25.0, "C");
+    stream1.setPressure(10.0, "bara");
+
+    Separator separator = new Separator("Separator1", stream1);
+
+    process.add(stream1);
+    process.add(separator);
+    process.run();
+
+    String report = process.getMassBalanceReport("kg/hr");
+    assertTrue(report.contains("Process:"));
+    assertTrue(report.contains("Separator1"));
+
+    String failedReport = process.getFailedMassBalanceReport("kg/hr", 0.1);
+    assertTrue(failedReport.contains("All unit operations passed mass balance check."));
+  }
+
+  @Test
   public void testMassBalanceComplexProcess() {
     // Test mass balance on a more complex process with multiple units
     neqsim.thermo.system.SystemInterface fluid1 =


### PR DESCRIPTION
## Summary
- add formatted mass balance and failed-mass-balance report helpers to `ProcessSystem` for single process systems
- cover report generation with a dedicated unit test

## Testing
- mvn -q -DskipTests=false -Dtest=ProcessSystemTest#testMassBalanceReportGeneration test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69254db807e8832d8a49dd145f3addc0)