### PR TITLE
Ensure heat exchanger mass balance

### DIFF
--- a/src/main/java/neqsim/process/equipment/heatexchanger/HeatExchanger.java
+++ b/src/main/java/neqsim/process/equipment/heatexchanger/HeatExchanger.java
@@ -240,6 +240,7 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface {
     testOps.PHflash(enthalpyOutRef);
     System.out.println("out temperature " + systemOut0.getTemperature("C"));
     outStream[nonOutStreamSpecifiedStreamNumber].setFluid(systemOut0);
+    alignOutStreamFlowRates();
   }
 
   /**
@@ -324,6 +325,8 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface {
 
       UAvalue = dEntalphy / (outStream[streamToSet].getThermoSystem().getTemperature()
           - inStream[streamToSet].getThermoSystem().getTemperature());
+
+      alignOutStreamFlowRates();
     }
 
     setCalculationIdentifier(id);
@@ -421,6 +424,7 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface {
       }
       duty = dEntalphy;
       hotColdDutyBalance = 1.0;
+      alignOutStreamFlowRates();
       // outStream[0].displayResult();
       // outStream[1].displayResult();
       // System.out.println("temperatur Stream 1 out " +
@@ -765,5 +769,13 @@ public class HeatExchanger extends Heater implements HeatExchangerInterface {
   public void setDeltaT(double deltaT) {
     useDeltaT = true;
     this.deltaT = deltaT;
+  }
+
+  private void alignOutStreamFlowRates() {
+    for (int i = 0; i < outStream.length; i++) {
+      if (outStream[i] != null && inStream[i] != null) {
+        outStream[i].setFlowRate(inStream[i].getFlowRate("kg/sec"), "kg/sec");
+      }
+    }
   }
 }

--- a/src/test/java/neqsim/process/equipment/heatexchanger/HeatExchangerMassBalanceTest.java
+++ b/src/test/java/neqsim/process/equipment/heatexchanger/HeatExchangerMassBalanceTest.java
@@ -1,0 +1,62 @@
+package neqsim.process.equipment.heatexchanger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+class HeatExchangerMassBalanceTest {
+
+  @Test
+  void maintainsMassBalanceDuringRun() {
+    Stream hot = createStream("hot", 1200.0, 90.0);
+    Stream cold = createStream("cold", 800.0, 20.0);
+
+    HeatExchanger hx = new HeatExchanger("hx", hot, cold);
+    hx.setUAvalue(750.0);
+    hx.setThermalEffectiveness(0.7);
+
+    ProcessSystem system = new ProcessSystem();
+    system.add(hot);
+    system.add(cold);
+    system.add(hx);
+    system.run();
+
+    assertEquals(hot.getFlowRate("kg/hr"), hx.getOutStream(0).getFlowRate("kg/hr"), 1e-10);
+    assertEquals(cold.getFlowRate("kg/hr"), hx.getOutStream(1).getFlowRate("kg/hr"), 1e-10);
+  }
+
+  @Test
+  void maintainsMassBalanceWithDeltaTSpecification() {
+    Stream hot = createStream("hot", 950.0, 110.0);
+    Stream cold = createStream("cold", 500.0, 30.0);
+
+    HeatExchanger hx = new HeatExchanger("hxDeltaT", hot, cold);
+    hx.setDeltaT(8.0);
+
+    ProcessSystem system = new ProcessSystem();
+    system.add(hot);
+    system.add(cold);
+    system.add(hx);
+    system.run();
+
+    assertEquals(hot.getFlowRate("kg/hr"), hx.getOutStream(0).getFlowRate("kg/hr"), 1e-10);
+    assertEquals(cold.getFlowRate("kg/hr"), hx.getOutStream(1).getFlowRate("kg/hr"), 1e-10);
+  }
+
+  private Stream createStream(String name, double flowRate, double temperatureC) {
+    SystemInterface system = new SystemSrkEos(273.15 + temperatureC, 30.0);
+    system.addComponent("methane", 80.0);
+    system.addComponent("ethane", 20.0);
+    system.createDatabase(true);
+    system.setMixingRule(2);
+
+    Stream stream = new Stream(name, system);
+    stream.setTemperature(temperatureC, "C");
+    stream.setPressure(40.0, "bara");
+    stream.setFlowRate(flowRate, "kg/hr");
+    return stream;
+  }
+}


### PR DESCRIPTION
## Summary
- align heat exchanger outlet flow rates with their corresponding inlets during calculations to maintain mass balance
- add regression tests to confirm mass flow is preserved for standard and deltaT-specified runs

## Testing
- mvn -Dtest=HeatExchangerMassBalanceTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69255495bee0832d886f8d6dd7bb0f95)