### PR TITLE
Add mass balance calculation to TurboExpanderCompressor

### DIFF
--- a/src/main/java/neqsim/process/equipment/expander/TurboExpanderCompressor.java
+++ b/src/main/java/neqsim/process/equipment/expander/TurboExpanderCompressor.java
@@ -1341,4 +1341,23 @@ public class TurboExpanderCompressor extends Expander {
   public void setExpanderDesignIsentropicEfficiency(double expanderDesignIsentropicEfficiency) {
     this.expanderDesignIsentropicEfficiency = expanderDesignIsentropicEfficiency;
   }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getMassBalance(String unit) {
+    double expanderBalance = 0.0;
+    double compressorBalance = 0.0;
+
+    if (expanderFeedStream != null && expanderOutletStream != null) {
+      expanderBalance = expanderOutletStream.getFlowRate(unit)
+          - expanderFeedStream.getFlowRate(unit);
+    }
+
+    if (compressorFeedStream != null && compressorOutletStream != null) {
+      compressorBalance = compressorOutletStream.getFlowRate(unit)
+          - compressorFeedStream.getFlowRate(unit);
+    }
+
+    return expanderBalance + compressorBalance;
+  }
 }


### PR DESCRIPTION
## Summary
- add a mass balance calculation override for TurboExpanderCompressor covering expander and compressor sections
- extend the mass balance test to validate the new calculation method

## Testing
- mvn -pl . -Dtest=TurboExpanderCompressorTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69255a072d6c832da8999453a9f4526a)