### PR TITLE
Improve valve flash failure fallback handling

### DIFF
--- a/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
+++ b/src/main/java/neqsim/process/equipment/valve/ThrottlingValve.java
@@ -310,11 +310,25 @@ public class ThrottlingValve extends TwoPortEquipment implements ValveInterface 
           }
         }
       }
-      outStream.setThermoSystem(thermoSystem);
     } catch (Exception ex) {
       logger.error("Valve {} calculation failed, keeping inlet state", getName(), ex);
-      outStream.setThermoSystem(thermoSystem);
+      thermoSystem = inStream.getThermoSystem().clone();
+      thermoSystem.setPressure(outPres, pressureUnit);
+      try {
+        thermoSystem.init(1);
+      } catch (Exception initEx) {
+        logger.error("Fallback initialization failed in valve {}", getName(), initEx);
+      }
     }
+
+    if (thermoSystem == null || Double.isNaN(thermoSystem.getTemperature())
+        || Double.isNaN(thermoSystem.getPressure())) {
+      thermoSystem = inStream.getThermoSystem().clone();
+      thermoSystem.setPressure(outPres, pressureUnit);
+      thermoSystem.init(0);
+    }
+
+    outStream.setThermoSystem(thermoSystem);
 
     setCalculationIdentifier(id);
   }


### PR DESCRIPTION
## Summary
- add fallback cloning and reinitialization when valve flashes fail to keep simulations running
- ensure invalid thermodynamic states are replaced with inlet-based state at target pressure

## Testing
- mvn -q -Dtest=ProcessSystemSerializationTest#runTEGProcessTest2 test *(fails: repository 502 Bad Gateway while resolving maven-enforcer-plugin dependency)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256cca4324832d8c6159964b0f602b)