### PR TITLE
Add mass balance support to flare and furnace units

### DIFF
--- a/src/main/java/neqsim/process/equipment/reactor/FurnaceBurner.java
+++ b/src/main/java/neqsim/process/equipment/reactor/FurnaceBurner.java
@@ -233,4 +233,15 @@ public class FurnaceBurner extends ProcessEquipmentBaseClass {
 
     setCalculationIdentifier(id);
   }
+
+  /** {@inheritDoc} */
+  @Override
+  public double getMassBalance(String unit) {
+    if (fuelInlet == null || airInlet == null || outletStream == null) {
+      return Double.NaN;
+    }
+
+    double inletMass = fuelInlet.getFlowRate(unit) + airInlet.getFlowRate(unit);
+    return outletStream.getFlowRate(unit) - inletMass;
+  }
 }


### PR DESCRIPTION
## Summary
- track inlet, assist, and emission mass flow in the flare stack to calculate mass balance results
- expose mass balance reporting for the furnace burner based on fuel, air, and outlet flows

## Testing
- Not run (command hung in this environment): `mvn -DskipTests compile`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256c90abcc832d918d18c174988b6c)