### PR TITLE
Cache volume-correction mixing values

### DIFF
--- a/src/main/java/neqsim/thermo/phase/PhasePrEosvolcor.java
+++ b/src/main/java/neqsim/thermo/phase/PhasePrEosvolcor.java
@@ -24,6 +24,9 @@ public class PhasePrEosvolcor extends PhasePrEos {
   private double CT;
   public double C;
   public double Ctot = 0;
+  private double[] cachedCi;
+  private double[] cachedCiT;
+  private double[][] cachedCij;
 
   /**
    * Creates new PhaseSrkEos.
@@ -37,8 +40,20 @@ public class PhasePrEosvolcor extends PhasePrEos {
   public void init(double totalNumberOfMoles, int numberOfComponents, int initType, PhaseType pt,
       double beta) {
     super.init(totalNumberOfMoles, numberOfComponents, initType, pt, beta);
+    cachedCi = null;
+    cachedCiT = null;
+    cachedCij = null;
     loc_C = calcC(this, temperature, pressure, numberOfComponents);
     CT = calcCT(this, temperature, pressure, numberOfComponents);
+    if (initType >= 1) {
+      ensureCiCache(numberOfComponents);
+    }
+    if (initType >= 2) {
+      ensureCiTCache(numberOfComponents);
+    }
+    if (initType >= 3) {
+      ensureCijCache(numberOfComponents);
+    }
   }
 
   /**
@@ -144,16 +159,8 @@ public class PhasePrEosvolcor extends PhasePrEos {
    */
   public double calcCi(int compNumb, PhaseInterface phase, double temperature, double pressure,
       int numbcomp) {
-    double Ci = 0.0;
-
-    ComponentEosInterface[] compArray = (ComponentEosInterface[]) phase.getcomponentArray();
-
-    for (int j = 0; j < numbcomp; j++) {
-      Ci += compArray[j].getNumberOfMolesInPhase() * getcij(compArray[compNumb], compArray[j]);
-    }
-
-    Ci = (2.0 * Ci - getC()) / phase.getNumberOfMolesInPhase();
-    return Ci;
+    ensureCiCache(numbcomp);
+    return cachedCi[compNumb];
   }
 
   /**
@@ -171,12 +178,8 @@ public class PhasePrEosvolcor extends PhasePrEos {
    */
   public double calcCij(int compNumb, int compNumbj, PhaseInterface phase, double temperature,
       double pressure, int numbcomp) {
-    double cij = 0.0;
-    ComponentEosInterface[] compArray = (ComponentEosInterface[]) phase.getcomponentArray();
-
-    cij = getcij(compArray[compNumb], compArray[compNumbj]);
-    return (2.0 * cij - ((ComponentPRvolcor) compArray[compNumb]).getCi()
-        - ((ComponentPRvolcor) compArray[compNumbj]).getCi()) / phase.getNumberOfMolesInPhase();
+    ensureCijCache(numbcomp);
+    return cachedCij[compNumb][compNumbj];
   }
 
   /**
@@ -193,16 +196,8 @@ public class PhasePrEosvolcor extends PhasePrEos {
    */
   public double calcCiT(int compNumb, PhaseInterface phase, double temperature, double pressure,
       int numbcomp) {
-    double CiT = 0.0;
-
-    ComponentEosInterface[] compArray = (ComponentEosInterface[]) phase.getcomponentArray();
-
-    for (int j = 0; j < numbcomp; j++) {
-      CiT += compArray[j].getNumberOfMolesInPhase() * getcijT(compArray[compNumb], compArray[j]);
-    }
-
-    CiT = (2.0 * CiT - getCT()) / phase.getNumberOfMolesInPhase();
-    return CiT;
+    ensureCiTCache(numbcomp);
+    return cachedCiT[compNumb];
   }
 
   /**
@@ -230,6 +225,57 @@ public class PhasePrEosvolcor extends PhasePrEos {
     return locCT / phase.getNumberOfMolesInPhase();
   }
 
+  private void ensureCiCache(int numbcomp) {
+    if (cachedCi != null && cachedCi.length >= numbcomp) {
+      return;
+    }
+
+    cachedCi = new double[numbcomp];
+    ComponentEosInterface[] compArray = (ComponentEosInterface[]) this.getcomponentArray();
+    double totalMolesInPhase = getNumberOfMolesInPhase();
+    for (int i = 0; i < numbcomp; i++) {
+      double CiVal = 0.0;
+      for (int j = 0; j < numbcomp; j++) {
+        CiVal += compArray[j].getNumberOfMolesInPhase() * getcij(compArray[i], compArray[j]);
+      }
+      cachedCi[i] = (2.0 * CiVal - getC()) / totalMolesInPhase;
+    }
+  }
+
+  private void ensureCiTCache(int numbcomp) {
+    if (cachedCiT != null && cachedCiT.length >= numbcomp) {
+      return;
+    }
+
+    cachedCiT = new double[numbcomp];
+    ComponentEosInterface[] compArray = (ComponentEosInterface[]) this.getcomponentArray();
+    double totalMolesInPhase = getNumberOfMolesInPhase();
+    for (int i = 0; i < numbcomp; i++) {
+      double CiTVal = 0.0;
+      for (int j = 0; j < numbcomp; j++) {
+        CiTVal += compArray[j].getNumberOfMolesInPhase() * getcijT(compArray[i], compArray[j]);
+      }
+      cachedCiT[i] = (2.0 * CiTVal - getCT()) / totalMolesInPhase;
+    }
+  }
+
+  private void ensureCijCache(int numbcomp) {
+    if (cachedCij != null && cachedCij.length >= numbcomp) {
+      return;
+    }
+
+    cachedCij = new double[numbcomp][numbcomp];
+    ComponentEosInterface[] compArray = (ComponentEosInterface[]) this.getcomponentArray();
+    double totalMolesInPhase = getNumberOfMolesInPhase();
+    for (int i = 0; i < numbcomp; i++) {
+      for (int j = 0; j < numbcomp; j++) {
+        double cij = getcij(compArray[i], compArray[j]);
+        cachedCij[i][j] = (2.0 * cij - ((ComponentPRvolcor) compArray[i]).getCi()
+            - ((ComponentPRvolcor) compArray[j]).getCi()) / totalMolesInPhase;
+      }
+    }
+  }
+
   /**
    * <p>
    * calcC.
@@ -253,11 +299,12 @@ public class PhasePrEosvolcor extends PhasePrEos {
     }
     C /= phase.getNumberOfMolesInPhase();
     Ctot = C;
+    loc_C = C;
     return C;
   }
 
   private double loc_C() {
-    return calcC(this, temperature, pressure, numberOfComponents);
+    return loc_C;
   }
 
   /**

--- a/src/test/java/neqsim/thermo/system/SystemPrEosvolcorThermodynamicConsistencyTest.java
+++ b/src/test/java/neqsim/thermo/system/SystemPrEosvolcorThermodynamicConsistencyTest.java
@@ -96,4 +96,25 @@ public class SystemPrEosvolcorThermodynamicConsistencyTest extends neqsim.NeqSim
         prepareSystem(system, new double[] {4.0e-5, 3.5e-5, 2.5e-5});
     assertThermodynamicConsistency(modelTest);
   }
+
+  @Test
+  @DisplayName("Thermodynamic consistency is preserved after repeated cached property calls")
+  public void testCachedPropertyThermodynamicConsistency() {
+    SystemInterface system = new SystemPrEosvolcor(320.0, 60.0);
+    system.addComponent("methane", 0.6);
+    system.addComponent("ethane", 0.25);
+    system.addComponent("propane", 0.15);
+    system.setMixingRule("classic");
+
+    ThermodynamicModelTest modelTest =
+        prepareSystem(system, new double[] {3.0e-5, 2.5e-5, 2.0e-5});
+    assertThermodynamicConsistency(modelTest);
+
+    system.init(3);
+    system.initProperties();
+    system.init(3);
+    system.initProperties();
+
+    assertThermodynamicConsistency(new ThermodynamicModelTest(system));
+  }
 }


### PR DESCRIPTION
## Summary
- cache the mixture volume translation term in PhasePrEosvolcor to avoid repeated O(N²) recalculation during property evaluations
- cache per-component Ci, CiT, and Cij arrays during phase init so subsequent fugacity/derivative calls avoid O(N³) work
- add a ThermodynamicModelTest regression to ensure cached PR volume-correction properties remain thermodynamically consistent after repeated property calls

## Testing
- mvn -Dtest=SystemPrEosvolcorThermodynamicConsistencyTest -DfailIfNoTests=false -B test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692896035950832db17eabc900af5a8a)