### PR TITLE
Use LBC critical volume correlation for pseudo components

### DIFF
--- a/src/main/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/viscosity/LBCViscosityMethod.java
+++ b/src/main/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/viscosity/LBCViscosityMethod.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import neqsim.physicalproperties.system.PhysicalProperties;
 import neqsim.thermo.ThermodynamicConstantsInterface;
+import neqsim.thermo.component.ComponentInterface;
 
 /**
  * <p>
@@ -44,15 +45,24 @@ public class LBCViscosityMethod extends Viscosity {
     double volumeMixRooted = 0.0;
     double epsilonMixSum = 0.0;
     for (int i = 0; i < phase.getPhase().getNumberOfComponents(); i++) {
-      double criticalVolume = phase.getPhase().getComponent(i).getCriticalVolume();
+      ComponentInterface component = phase.getPhase().getComponent(i);
+      double criticalVolume = component.getCriticalVolume();
+
+      if (criticalVolume <= 0.0 && (component.isIsTBPfraction() || component.isIsPlusFraction())
+          && component.getNormalLiquidDensity() > 0.0) {
+        double molarMass = component.getMolarMass() * 1000.0; // g/mol
+        double liquidDensity = component.getNormalLiquidDensity(); // g/cm3
+        criticalVolume = 21.573 + 0.015122 * molarMass - 27.656 * liquidDensity
+            + 0.070615 * molarMass * liquidDensity; // cm3/mol
+      }
+
       if (criticalVolume <= 0.0) {
-        double criticalCompressibility = phase.getPhase().getComponent(i)
-            .getCriticalCompressibilityFactor();
+        double criticalCompressibility = component.getCriticalCompressibilityFactor();
         if (criticalCompressibility <= 0.0) {
           criticalCompressibility = 0.28; // typical default when no data is available
         }
-        double tc = phase.getPhase().getComponent(i).getTC();
-        double pc = phase.getPhase().getComponent(i).getPC();
+        double tc = component.getTC();
+        double pc = component.getPC();
         criticalVolume = criticalCompressibility * ThermodynamicConstantsInterface.R * tc
             / (pc * 1.0e5);
       }


### PR DESCRIPTION
## Summary
- add a pseudo/plus-fraction critical volume correlation to the LBC viscosity calculation when no critical volume is set
- continue to fall back to compressibility-based estimates and unit conversions before applying the mixing rule

## Testing
- mvn -q -Dtest=neqsim.physicalproperties.methods.commonphasephysicalproperties.viscosity.LBCViscosityMethodTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928c6903bd8832d99f6eba58b501d72)