### PR TITLE
Add gas inflow models and document well and choke simulation

### DIFF
--- a/docs/well_and_choke_simulation.md
+++ b/docs/well_and_choke_simulation.md
@@ -1,0 +1,21 @@
+# Well and choke simulation in NeqSim
+
+## Overview
+NeqSim combines well inflow performance relationships with hydraulic flowline models and production chokes to represent surface networks. A `WellFlowlineNetwork` assembles wells, optional chokes, and pipelines into branches that are gathered in manifolds for steady-state or transient calculations.
+
+## Well inflow models
+`WellFlow` supports several inflow performance relationships that can either solve for outlet pressure from a specified flow or compute flow from a specified outlet pressure:
+
+- **Production index (PI)** – Constant PI using squared-pressure drawdown.
+- **Vogel** – Empirical oil well relationship using a reference test to derive the productivity curve.
+- **Fetkovich** – Gas deliverability using C and n coefficients in squared-pressure space.
+- **Backpressure with non-Darcy term** – Deliverability equation \(p_r^2 - p_{wf}^2 = a \cdot q + b \cdot q^2\) where the quadratic term captures turbulence/non-Darcy skin. The model is solved in either direction, with guards for insufficient drawdown.
+- **Table-driven inflow** – User-supplied pairs of bottom-hole pressure and flow rate are sorted and linearly interpolated to compute flow or back-calculate the required pressure for a requested rate.
+
+All models can switch between computing outlet pressure or flow via `solveFlowFromOutletPressure(boolean)`, enabling backpressure solves from downstream network pressure when desired.
+
+## Choke representation
+Production chokes are modeled as `ThrottlingValve` instances using IEC 60534 sizing. Chokes can be attached per branch and run in steady-state or transient mode. Valve travel and characterization are captured through the underlying valve model, and choking conditions can be toggled and tuned at the valve level.
+
+## Network coupling
+`WellFlowlineNetwork` wires wells and optional chokes into `PipeBeggsAndBrills` flowlines, collects them in manifolds, and optionally sends the combined stream downstream. The network offers steady-state and transient execution modes, supports target endpoint pressure solving, and can propagate arrival pressures back to well outlets for iterative backpressure calculations.

--- a/src/main/java/neqsim/process/equipment/reservoir/WellFlow.java
+++ b/src/main/java/neqsim/process/equipment/reservoir/WellFlow.java
@@ -34,7 +34,11 @@ public class WellFlow extends TwoPortEquipment {
     /** Vogel correlation for solution gas drive wells. */
     VOGEL,
     /** Fetkovich correlation for gas wells. */
-    FETKOVICH
+    FETKOVICH,
+    /** Backpressure equation with optional non-Darcy term. */
+    BACKPRESSURE,
+    /** Table-driven inflow curve (flow vs. bottom-hole pressure). */
+    TABLE
   }
 
   InflowPerformanceModel inflowModel = InflowPerformanceModel.PRODUCTION_INDEX;
@@ -44,6 +48,12 @@ public class WellFlow extends TwoPortEquipment {
   // Fetkovich parameters
   double fetkovichC = 0.0;
   double fetkovichN = 1.0;
+  // Backpressure parameters
+  double backpressureA = 0.0;
+  double backpressureB = 0.0;
+  // Table-driven inflow parameters
+  double[] inflowTablePwf = new double[0];
+  double[] inflowTableRate = new double[0];
 
   /**
    * <p>
@@ -103,6 +113,36 @@ public class WellFlow extends TwoPortEquipment {
           double flow = fetkovichC
               * Math.pow(Math.pow(presRes, 2.0) - Math.pow(pwf, 2.0), fetkovichN);
           outStream.setFlowRate(flow, "MSm3/day");
+        }
+        break;
+      case BACKPRESSURE:
+        if (calcpressure) {
+          double q = getInletStream().getFlowRate("MSm3/day");
+          double delta = backpressureA * q + backpressureB * Math.pow(q, 2.0);
+          if (Math.pow(presRes, 2.0) - delta < 0) {
+            logger.error("pressure lower that 0");
+            throw new RuntimeException(new neqsim.util.exception.InvalidInputException("WellFlow",
+                "run:calcOutletPressure", "pressure", "- Outlet pressure is negative" + pressureOut));
+          }
+          outStream.setPressure(Math.sqrt(Math.pow(presRes, 2.0) - delta), "bara");
+        } else {
+          double pwf = thermoSystem.getPressure("bara");
+          double delta = Math.pow(presRes, 2.0) - Math.pow(pwf, 2.0);
+          double flow = computeBackpressureFlow(delta);
+          outStream.setFlowRate(flow, "MSm3/day");
+        }
+        break;
+      case TABLE:
+        if (inflowTablePwf.length < 2 || inflowTableRate.length < 2) {
+          throw new RuntimeException(new neqsim.util.exception.InvalidInputException("WellFlow",
+              "run", "table", "- Table-driven inflow requires at least two points"));
+        }
+        if (calcpressure) {
+          double q = getInletStream().getFlowRate("MSm3/day");
+          outStream.setPressure(interpolatePressureForFlow(q), "bara");
+        } else {
+          double pwf = thermoSystem.getPressure("bara");
+          outStream.setFlowRate(interpolateFlowForPressure(pwf), "MSm3/day");
         }
         break;
       case PRODUCTION_INDEX:
@@ -231,6 +271,46 @@ public class WellFlow extends TwoPortEquipment {
   }
 
   /**
+   * Use backpressure equation for gas wells: p<sub>res</sub><sup>2</sup> - p<sub>wf</sub><sup>2</sup> =
+   * a·q + b·q². Parameter {@code b} captures non-Darcy (turbulence) effects.
+   *
+   * @param a deliverability coefficient a
+   * @param b deliverability coefficient b (non-Darcy component)
+   * @param reservoirPressure reservoir pressure in bara (stored for reference)
+   */
+  public void setBackpressureParameters(double a, double b, double reservoirPressure) {
+    this.inflowModel = InflowPerformanceModel.BACKPRESSURE;
+    this.useWellProductionIndex = false;
+    this.backpressureA = a;
+    this.backpressureB = b;
+    this.vogelRefPres = reservoirPressure;
+  }
+
+  /**
+   * Provide tabulated inflow data (flow rate vs. bottom-hole pressure). Arrays are sorted by
+   * pressure internally to allow monotonic interpolation.
+   *
+   * @param bottomHolePressures bottom-hole flowing pressures in bara
+   * @param flowRates flow rates corresponding to each pressure point (same unit as stream)
+   */
+  public void setTableInflow(double[] bottomHolePressures, double[] flowRates) {
+    if (bottomHolePressures == null || flowRates == null || bottomHolePressures.length != flowRates.length
+        || bottomHolePressures.length < 2) {
+      throw new RuntimeException(new neqsim.util.exception.InvalidInputException("WellFlow",
+          "setTableInflow", "table",
+          "- Provide matching pressure/flow arrays with at least two entries"));
+    }
+
+    this.inflowModel = InflowPerformanceModel.TABLE;
+    this.useWellProductionIndex = false;
+
+    // copy and sort by pressure to support interpolation in either direction
+    inflowTablePwf = java.util.Arrays.copyOf(bottomHolePressures, bottomHolePressures.length);
+    inflowTableRate = java.util.Arrays.copyOf(flowRates, flowRates.length);
+    sortTableByPressure();
+  }
+
+  /**
    * Estimate well production index from Darcy law parameters. Units: permeability in mD,
    * viscosity in cP and lengths in meter.
    *
@@ -246,5 +326,76 @@ public class WellFlow extends TwoPortEquipment {
     double numerator = 0.00708 * permeability * thickness;
     double denominator = viscosity * (Math.log(reservoirRadius / wellRadius) + skinFactor);
     setWellProductionIndex(numerator / denominator);
+  }
+
+  private double computeBackpressureFlow(double drawdown) {
+    if (backpressureA == 0.0 && backpressureB == 0.0) {
+      throw new RuntimeException(new neqsim.util.exception.InvalidInputException("WellFlow",
+          "run:calcFlow", "flow", "- Backpressure parameters a and b must be specified"));
+    }
+    if (backpressureB == 0.0) {
+      return drawdown / backpressureA;
+    }
+    double discriminant = Math.pow(backpressureA, 2.0) + 4.0 * backpressureB * drawdown;
+    if (discriminant < 0) {
+      logger.error("pressure lower that 0");
+      throw new RuntimeException(new neqsim.util.exception.InvalidInputException("WellFlow",
+          "run:calcFlow", "flow", "- Drawdown is insufficient for backpressure calculation"));
+    }
+    return (-backpressureA + Math.sqrt(discriminant)) / (2.0 * backpressureB);
+  }
+
+  private double interpolateFlowForPressure(double pwf) {
+    if (pwf <= inflowTablePwf[0]) {
+      return inflowTableRate[0];
+    }
+    int lastIndex = inflowTablePwf.length - 1;
+    if (pwf >= inflowTablePwf[lastIndex]) {
+      return inflowTableRate[lastIndex];
+    }
+    for (int i = 0; i < lastIndex; i++) {
+      double lowP = inflowTablePwf[i];
+      double highP = inflowTablePwf[i + 1];
+      if (pwf >= lowP && pwf <= highP) {
+        double fraction = (pwf - lowP) / (highP - lowP);
+        return inflowTableRate[i] + fraction * (inflowTableRate[i + 1] - inflowTableRate[i]);
+      }
+    }
+    return inflowTableRate[lastIndex];
+  }
+
+  private double interpolatePressureForFlow(double flow) {
+    if (flow <= inflowTableRate[0]) {
+      return inflowTablePwf[0];
+    }
+    int lastIndex = inflowTableRate.length - 1;
+    if (flow >= inflowTableRate[lastIndex]) {
+      return inflowTablePwf[lastIndex];
+    }
+    for (int i = 0; i < lastIndex; i++) {
+      double lowQ = inflowTableRate[i];
+      double highQ = inflowTableRate[i + 1];
+      if (flow >= lowQ && flow <= highQ) {
+        double fraction = (flow - lowQ) / (highQ - lowQ);
+        return inflowTablePwf[i] + fraction * (inflowTablePwf[i + 1] - inflowTablePwf[i]);
+      }
+    }
+    return inflowTablePwf[lastIndex];
+  }
+
+  private void sortTableByPressure() {
+    for (int i = 0; i < inflowTablePwf.length - 1; i++) {
+      for (int j = 0; j < inflowTablePwf.length - i - 1; j++) {
+        if (inflowTablePwf[j] > inflowTablePwf[j + 1]) {
+          double tempP = inflowTablePwf[j];
+          inflowTablePwf[j] = inflowTablePwf[j + 1];
+          inflowTablePwf[j + 1] = tempP;
+
+          double tempQ = inflowTableRate[j];
+          inflowTableRate[j] = inflowTableRate[j + 1];
+          inflowTableRate[j + 1] = tempQ;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add backpressure and table-driven inflow options for gas wells alongside existing correlations
- improve well inflow handling with non-Darcy support and table interpolation safeguards
- document how NeqSim simulates wells, production chokes, and flowline networks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692dfdd147ac832db015ad92d9c1f3b5)