### PR TITLE
Fix ProductionOptimizer test temp file writing

### DIFF
--- a/src/test/java/neqsim/process/util/optimization/ProductionOptimizerTest.java
+++ b/src/test/java/neqsim/process/util/optimization/ProductionOptimizerTest.java
@@ -1,5 +1,6 @@
 package neqsim.process.util.optimization;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -342,7 +343,7 @@ public class ProductionOptimizerTest {
         "      penaltyWeight: 0.0", "      description: Keep compressor within design");
 
     Path specFile = Files.createTempFile("optimization", ".yaml");
-    Files.writeString(specFile, yaml);
+    Files.write(specFile, yaml.getBytes(StandardCharsets.UTF_8));
 
     List<ProductionOptimizer.ScenarioRequest> scenarios = ProductionOptimizationSpecLoader
         .load(specFile, processes, feeds, metrics);


### PR DESCRIPTION
## Summary
- add explicit UTF-8 encoding when writing temporary optimization spec
- ensure test uses JDK8-compatible Files.write API

## Testing
- mvn -DskipTests test-compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e0d25bf7c832d8a9a6e4d4a06799a)