### PR TITLE
Document distillation diagnostics and EOS-CG updates

### DIFF
--- a/docs/thermo/gerg2008_eoscg.md
+++ b/docs/thermo/gerg2008_eoscg.md
@@ -102,6 +102,11 @@ Includes all 21 components from GERG-2008, plus:
 *   Chlorine (Cl₂)
 *   Carbonyl Sulfide (COS)
 
+Recent PRs refreshed the EOS-CG component tables with updated critical properties and binary
+interaction data, improving phase behavior for acid-gas heavy blends. The refresh aligns the
+library with the latest GERG-compatible datasets so CCS mixtures match reference densities and
+sound speed benchmarks more closely.
+
 ### Usage in NeqSim
 
 To use EOS-CG in NeqSim, use the `SystemEOSCGEos` class.

--- a/docs/wiki/distillation_column.md
+++ b/docs/wiki/distillation_column.md
@@ -80,6 +80,8 @@ stability.
 - Convergence metric: average absolute temperature change.
 - Relaxation policy: decreases when combined residual (temperature, mass, energy) grows by
   more than 5 %, increases when it shrinks by more than 2 %.
+- Default tolerances were tightened in recent iterations (temperature to 0.01 K, mass/energy to
+  1e-4 relative) to prevent premature termination when using highly non-ideal feeds.
 
 ### Inside-out specifics
 
@@ -89,6 +91,10 @@ stability.
   more often near convergence.
 - Optional polishing stage tightens tolerances to 1e-5 K / relative mass 1e-4 when base tolerances
   are met but the user requires stricter balances.
+- Tracks per-iteration mass and energy residuals alongside relaxed stream norms so operators can
+  audit the inside-out trajectory when debugging column stability.
+- Records the peak relaxation factors applied to trays, providing a quick signal when the column
+  required aggressive damping to converge.
 
 ### Matrix solver specifics
 


### PR DESCRIPTION
## Summary
- describe tighter distillation solver tolerances and provide new inside-out diagnostics documentation
- note recent EOS-CG component table refresh for CCS mixtures

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e63ff1104832da9d9329e9c7fcc49)