### PR TITLE
Allow tuning of LBC viscosity parameters

### DIFF
--- a/src/main/java/neqsim/physicalproperties/system/PhysicalProperties.java
+++ b/src/main/java/neqsim/physicalproperties/system/PhysicalProperties.java
@@ -242,6 +242,33 @@ public abstract class PhysicalProperties implements Cloneable, ThermodynamicCons
   }
 
   /**
+   * Set LBC dense-fluid contribution coefficients for tuning the viscosity correlation.
+   *
+   * @param parameters array of five LBC dense contribution parameters
+   */
+  public void setLbcParameters(double[] parameters) {
+    if (viscosityCalc instanceof LBCViscosityMethod) {
+      ((LBCViscosityMethod) viscosityCalc).setDenseContributionParameters(parameters);
+    } else {
+      throw new IllegalStateException("Current viscosity model is not LBC");
+    }
+  }
+
+  /**
+   * Set an individual LBC dense-fluid contribution parameter.
+   *
+   * @param index parameter index (0-4)
+   * @param value parameter value
+   */
+  public void setLbcParameter(int index, double value) {
+    if (viscosityCalc instanceof LBCViscosityMethod) {
+      ((LBCViscosityMethod) viscosityCalc).setDenseContributionParameter(index, value);
+    } else {
+      throw new IllegalStateException("Current viscosity model is not LBC");
+    }
+  }
+
+  /**
    * <p>
    * setDiffusionCoefficientModel.
    * </p>


### PR DESCRIPTION
## Summary
- allow overriding dense-fluid contribution parameters in the LBC viscosity model
- add PhysicalProperties helpers for tuning individual or grouped LBC coefficients
- cover tunable parameters with a new regression test

## Testing
- mvn -Dtest=LBCViscosityMethodTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e65b45794832d88e0fdd77a3637fa)