### PR TITLE
Add calculator presets for AI-friendly logic hooks

### DIFF
--- a/docs/process_calculator.md
+++ b/docs/process_calculator.md
@@ -1,6 +1,6 @@
 # Process Calculator
 
-The `Calculator` unit operation in NeqSim provides a flexible way to perform custom calculations and data manipulation within a process simulation. It allows users to define arbitrary logic that can read properties from input process equipment and modify properties of output process equipment.
+The `Calculator` unit operation in NeqSim provides a flexible way to perform custom calculations and data manipulation within a process simulation. It allows users to define arbitrary logic that can read properties from input process equipment and modify properties of output process equipment. Custom lambdas are the recommended hook for AI-generated calculations so you can swap in new behavior without rebuilding the process topology.
 
 This is particularly useful for:
 - Calculating derived properties (e.g., total energy, efficiency).
@@ -16,7 +16,7 @@ The `Calculator` class is located in `neqsim.process.equipment.util`.
 1.  **Create the Calculator**: Instantiate the `Calculator` with a name.
 2.  **Add Inputs**: Use `addInputVariable()` to add one or more process equipment objects (e.g., Streams) that will be used in the calculation.
 3.  **Set Output**: Use `setOutputVariable()` to set the target process equipment that will be modified by the calculation.
-4.  **Define Logic**: Use `setCalculationMethod()` to define the custom calculation logic. This method accepts a `BiConsumer<ArrayList<ProcessEquipmentInterface>, ProcessEquipmentInterface>`, which can be easily implemented using a Java Lambda expression.
+4.  **Define Logic**: Use `setCalculationMethod()` to define the custom calculation logic. This method accepts a `BiConsumer<ArrayList<ProcessEquipmentInterface>, ProcessEquipmentInterface>`, which can be easily implemented using a Java Lambda expression or a declarative preset.
 
 ### Example: Energy Calculation and Temperature Adjustment
 
@@ -81,6 +81,27 @@ public class CalculatorExample {
     }
 }
 ```
+
+### Declarative presets for common calculations
+
+When you want standardized behavior without re-implementing a lambda, use the presets in `CalculatorLibrary`:
+
+```java
+Calculator preset = new Calculator("energy balancer");
+preset.addInputVariable(inletStream);
+preset.setOutputVariable(outletStream);
+
+// Resolve by enum
+preset.setCalculationMethod(CalculatorLibrary.preset(CalculatorLibrary.Preset.ENERGY_BALANCE));
+
+// ...or dynamically by name from metadata/AI text
+// preset.setCalculationMethod(CalculatorLibrary.byName("energyBalance"));
+```
+
+Available presets:
+
+- **ENERGY_BALANCE**: flashes the output stream at its current pressure so its enthalpy equals the sum of input enthalpies.
+- **DEW_POINT_TARGETING**: sets the output stream temperature to the hydrocarbon dew point of the first input stream at the output pressure. Use `CalculatorLibrary.dewPointTargeting(double marginKelvin)` to add a temperature margin above dew point.
 
 ## API Reference
 

--- a/docs/wiki/logical_unit_operations.md
+++ b/docs/wiki/logical_unit_operations.md
@@ -4,7 +4,7 @@ NeqSim provides several "logical" unit operations that do not represent physical
 
 ## Calculator
 
-The `Calculator` unit operation allows for custom calculations and data manipulation within a process simulation. It is useful for calculating derived properties or implementing simple control logic.
+The `Calculator` unit operation allows for custom calculations and data manipulation within a process simulation. It is useful for calculating derived properties or implementing simple control logic. Custom lambdas are the preferred hook for AI-generated logic because they let you keep the same simulator graph while swapping in new behavior at runtime.
 
 ### Usage
 
@@ -29,9 +29,28 @@ energyCalc.setCalculationMethod((inputs, output) -> {
 });
 ```
 
+### Declarative presets (energy balance, dew point targeting)
+
+For frequently reused logic you can rely on `CalculatorLibrary` presets instead of hand-written lambdas. This makes it easier to reference calculations declaratively (e.g., from an AI agent or configuration file):
+
+```java
+Calculator presetCalc = new Calculator("dew point targeter");
+presetCalc.addInputVariable(feedStream);
+presetCalc.setOutputVariable(targetStream);
+
+// Apply by enum or by name
+presetCalc.setCalculationMethod(CalculatorLibrary.preset(CalculatorLibrary.Preset.DEW_POINT_TARGETING));
+// presetCalc.setCalculationMethod(CalculatorLibrary.byName("dewPointTargeting"));
+```
+
+Available presets:
+
+- **ENERGY_BALANCE** – matches the output stream enthalpy to the sum of input enthalpies by flashing at the output pressure.
+- **DEW_POINT_TARGETING** – sets the output stream temperature to the source stream dew point at the output pressure (optionally with a temperature margin via `CalculatorLibrary.dewPointTargeting(double marginKelvin)`).
+
 ## Adjuster
 
-The `Adjuster` is used to vary a parameter in one unit operation (the "adjusted variable") to achieve a specific value in another unit operation (the "target variable"). It is essentially a single-variable solver.
+The `Adjuster` is used to vary a parameter in one unit operation (the "adjusted variable") to achieve a specific value in another unit operation (the "target variable"). It is essentially a single-variable solver. Use lambdas for the getters/setters to keep the hook flexible for AI-generated control logic.
 
 ### Standard Usage
 

--- a/src/main/java/neqsim/process/equipment/util/CalculatorLibrary.java
+++ b/src/main/java/neqsim/process/equipment/util/CalculatorLibrary.java
@@ -1,0 +1,162 @@
+package neqsim.process.equipment.util;
+
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.function.BiConsumer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import neqsim.process.equipment.ProcessEquipmentInterface;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermodynamicoperations.ThermodynamicOperations;
+
+/**
+ * Catalog of reusable {@link Calculator} presets. These presets provide declarative building blocks
+ * that can be paired with {@link Calculator#setCalculationMethod(BiConsumer)} to encourage
+ * consistent AI- or rule-generated logic across simulations.
+ */
+public final class CalculatorLibrary {
+  private static final Logger logger = LogManager.getLogger(CalculatorLibrary.class);
+
+  private CalculatorLibrary() {}
+
+  /**
+   * Preset identifiers that can be resolved through {@link #byName(String)}.
+   */
+  public enum Preset {
+    /**
+     * Performs an enthalpy-based energy balance using the input streams and flashes the output
+     * stream at its current pressure to match the summed enthalpy.
+     */
+    ENERGY_BALANCE,
+
+    /**
+     * Sets the output stream temperature to the hydrocarbon dew point of the first input stream at
+     * the output stream's pressure.
+     */
+    DEW_POINT_TARGETING
+  }
+
+  /**
+   * Resolve a preset calculation by name (case-insensitive). This is useful when wiring calculators
+   * declaratively from metadata or AI-generated instructions.
+   *
+   * @param presetName the preset identifier (e.g., "energyBalance" or "dewPointTargeting")
+   * @return a {@link BiConsumer} ready for {@link Calculator#setCalculationMethod(BiConsumer)}
+   */
+  public static BiConsumer<ArrayList<ProcessEquipmentInterface>, ProcessEquipmentInterface> byName(
+      String presetName) {
+    if (presetName == null) {
+      throw new IllegalArgumentException("Preset name cannot be null");
+    }
+
+    String normalized = presetName.trim().toUpperCase(Locale.ROOT).replace(" ", "_")
+        .replace("-", "_");
+    if ("DEWPOINTTARGETING".equals(normalized)) {
+      normalized = "DEW_POINT_TARGETING";
+    } else if ("ENERGYBALANCE".equals(normalized)) {
+      normalized = "ENERGY_BALANCE";
+    }
+    try {
+      return preset(Preset.valueOf(normalized));
+    } catch (IllegalArgumentException ex) {
+      throw new IllegalArgumentException("Unknown calculator preset: " + presetName, ex);
+    }
+  }
+
+  /**
+   * Resolve a preset calculation.
+   *
+   * @param preset the preset identifier
+   * @return a {@link BiConsumer} ready for {@link Calculator#setCalculationMethod(BiConsumer)}
+   */
+  public static BiConsumer<ArrayList<ProcessEquipmentInterface>, ProcessEquipmentInterface> preset(
+      Preset preset) {
+    switch (preset) {
+      case ENERGY_BALANCE:
+        return energyBalance();
+      case DEW_POINT_TARGETING:
+        return dewPointTargeting();
+      default:
+        throw new IllegalArgumentException("Unsupported preset: " + preset);
+    }
+  }
+
+  /**
+   * Create an energy-balance calculator. The output stream is flashed at its current pressure so
+   * that its enthalpy equals the sum of the input stream enthalpies.
+   */
+  public static BiConsumer<ArrayList<ProcessEquipmentInterface>, ProcessEquipmentInterface>
+      energyBalance() {
+    return (inputs, output) -> {
+      Stream targetStream = requireStream(output, "energy balance output");
+
+      if (inputs == null || inputs.isEmpty()) {
+        throw new IllegalArgumentException("Energy balance requires at least one input stream");
+      }
+
+      double targetPressure = targetStream.getThermoSystem().getPressure();
+      double totalEnthalpy = 0.0;
+      for (ProcessEquipmentInterface equipment : inputs) {
+        Stream stream = requireStream(equipment, "energy balance input");
+        totalEnthalpy += stream.getThermoSystem().getEnthalpy();
+      }
+
+      ThermodynamicOperations ops = new ThermodynamicOperations(targetStream.getThermoSystem());
+      ops.getSystem().setPressure(targetPressure);
+      try {
+        ops.PHflash(totalEnthalpy);
+      } catch (Exception ex) {
+        logger.error("Energy balance flash failed", ex);
+        throw new IllegalStateException("Energy balance flash failed", ex);
+      }
+
+      targetStream.setThermoSystem(ops.getSystem());
+      targetStream.run();
+    };
+  }
+
+  /**
+   * Create a dew-point targeting calculator. It sets the output stream temperature to the
+   * hydrocarbon dew point of the first input stream at the output stream's current pressure. A
+   * small positive margin can be applied to stay above dew point.
+   *
+   * @param marginKelvin temperature margin to add to the dew point (K)
+   */
+  public static BiConsumer<ArrayList<ProcessEquipmentInterface>, ProcessEquipmentInterface>
+      dewPointTargeting(double marginKelvin) {
+    return (inputs, output) -> {
+      Stream sourceStream = requireFirstStream(inputs, "dew point source");
+      Stream targetStream = requireStream(output, "dew point target");
+
+      double referencePressure = targetStream.getThermoSystem().getPressure("bara");
+      double dewPointK =
+          sourceStream.getHydrocarbonDewPoint("K", referencePressure, "bara");
+
+      targetStream.setPressure(referencePressure, "bara");
+      targetStream.setTemperature(dewPointK + marginKelvin, "K");
+      targetStream.run();
+    };
+  }
+
+  /**
+   * Create a dew-point targeting calculator with zero temperature margin.
+   */
+  public static BiConsumer<ArrayList<ProcessEquipmentInterface>, ProcessEquipmentInterface>
+      dewPointTargeting() {
+    return dewPointTargeting(0.0);
+  }
+
+  private static Stream requireStream(ProcessEquipmentInterface equipment, String role) {
+    if (equipment instanceof Stream) {
+      return (Stream) equipment;
+    }
+    throw new IllegalArgumentException("Expected a Stream for " + role);
+  }
+
+  private static Stream requireFirstStream(ArrayList<ProcessEquipmentInterface> inputs, String role) {
+    if (inputs == null || inputs.isEmpty()) {
+      throw new IllegalArgumentException("Expected at least one input stream for " + role);
+    }
+    return requireStream(inputs.get(0), role);
+  }
+}

--- a/src/test/java/neqsim/process/equipment/util/CalculatorLibraryTest.java
+++ b/src/test/java/neqsim/process/equipment/util/CalculatorLibraryTest.java
@@ -1,0 +1,72 @@
+package neqsim.process.equipment.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemSrkEos;
+
+class CalculatorLibraryTest {
+
+  @Test
+  void energyBalanceMatchesInputEnthalpy() {
+    SystemSrkEos fluid = new SystemSrkEos(280.0, 50.0);
+    fluid.addComponent("methane", 0.9);
+    fluid.addComponent("ethane", 0.1);
+    fluid.createDatabase(true);
+    fluid.setMixingRule(2);
+
+    Stream inlet = new Stream("inlet", fluid);
+    inlet.setTemperature(280.0, "K");
+    inlet.setPressure(50.0, "bara");
+    inlet.run();
+
+    Stream outlet = new Stream("outlet", fluid.clone());
+    outlet.setTemperature(320.0, "K");
+    outlet.setPressure(50.0, "bara");
+    outlet.run();
+
+    Calculator calculator = new Calculator("Energy Balance");
+    calculator.addInputVariable(inlet);
+    calculator.setOutputVariable(outlet);
+    calculator.setCalculationMethod(CalculatorLibrary.energyBalance());
+
+    calculator.run();
+
+    double inletEnthalpy = inlet.getThermoSystem().getEnthalpy();
+    double outletEnthalpy = outlet.getThermoSystem().getEnthalpy();
+    assertEquals(inletEnthalpy, outletEnthalpy, Math.abs(inletEnthalpy) * 1e-6);
+  }
+
+  @Test
+  void dewPointTargetingUsesPresetResolver() {
+    SystemSrkEos fluid = new SystemSrkEos(290.0, 15.0);
+    fluid.addComponent("methane", 0.8);
+    fluid.addComponent("ethane", 0.2);
+    fluid.createDatabase(true);
+    fluid.setMixingRule(2);
+
+    Stream source = new Stream("source", fluid);
+    source.setPressure(15.0, "bara");
+    source.setTemperature(290.0, "K");
+    source.run();
+
+    Stream target = new Stream("target", fluid.clone());
+    target.setPressure(12.0, "bara");
+    target.setTemperature(320.0, "K");
+    target.run();
+
+    Calculator calculator = new Calculator("dew point targeter");
+    calculator.addInputVariable(source);
+    calculator.setOutputVariable(target);
+    calculator.setCalculationMethod(CalculatorLibrary.byName("dewPointTargeting"));
+
+    calculator.run();
+
+    double dewPoint = source.getHydrocarbonDewPoint("K",
+        target.getThermoSystem().getPressure("bara"), "bara");
+    assertEquals(dewPoint, target.getTemperature("K"), 1e-6);
+    assertTrue(target.getThermoSystem().getPressure() > 0.0);
+  }
+}


### PR DESCRIPTION
## Summary
- add a CalculatorLibrary with reusable energy-balance and dew-point-targeting presets plus a name resolver for declarative wiring
- document AI-friendly lambda hooks and preset usage across calculator, adjuster, and setpoint docs
- cover the presets with targeted unit tests for enthalpy matching and dew-point targeting

## Testing
- mvn -q -Dtest=CalculatorLibraryTest test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e6a21558c832d9aa4e43b6161124d)