### PR TITLE
Fix IntegratedSafetyChainTransientTest list initialization

### DIFF
--- a/src/test/java/neqsim/process/util/scenario/IntegratedSafetyChainTransientTest.java
+++ b/src/test/java/neqsim/process/util/scenario/IntegratedSafetyChainTransientTest.java
@@ -2,6 +2,7 @@ package neqsim.process.util.scenario;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -252,7 +253,7 @@ class IntegratedSafetyChainTransientTest {
 
     @Override
     public List<neqsim.process.equipment.ProcessEquipmentInterface> getTargetEquipment() {
-      return List.of(separator);
+      return Collections.singletonList(separator);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- replace Java 9 `List.of` usage in IntegratedSafetyChainTransientTest with `Collections.singletonList` for compatibility
- add Collections import to support singleton list creation

## Testing
- mvn -q -DskipTests test-compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e78625028832dace502b17377c677)