### PR TITLE
Add additional runnable examples

### DIFF
--- a/examples/neqsim/chemicalreactions/ChemicalEquilibriumExample.java
+++ b/examples/neqsim/chemicalreactions/ChemicalEquilibriumExample.java
@@ -1,0 +1,39 @@
+package neqsim.chemicalreactions;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Demonstrates solving a simple gas-phase combustion equilibrium using the chemical reaction
+ * utilities from the test suite.
+ */
+public class ChemicalEquilibriumExample {
+
+  private ChemicalEquilibriumExample() {}
+
+  public static void main(String[] args) {
+    SystemSrkEos testSystem = new SystemSrkEos(303.3, 2.8);
+    testSystem.addComponent("methane", 5.0, "kg/sec");
+    testSystem.addComponent("nitrogen", 100.0, "kg/sec");
+    testSystem.addComponent("oxygen", 40.0, "kg/sec");
+
+    testSystem.chemicalReactionInit();
+    testSystem.createDatabase(true);
+    testSystem.setMixingRule(2);
+    testSystem.init(0);
+    testSystem.setMaxNumberOfPhases(1);
+    testSystem.setNumberOfPhases(1);
+
+    try {
+      testSystem.getChemicalReactionOperations().solveChemEq(0, 0);
+      String composition = Arrays.stream(testSystem.getPhase(0).getComponents())
+          .map(comp -> comp.getName() + "=" + comp.getx() * 100.0 + " mol%")
+          .collect(Collectors.joining(", "));
+
+      System.out.println("Gas phase composition after equilibrium: " + composition);
+    } catch (Exception e) {
+      System.err.println("Chemical equilibrium calculation failed: " + e.getMessage());
+    }
+  }
+}

--- a/examples/neqsim/process/controllerdevice/MovingHorizonEstimationExample.java
+++ b/examples/neqsim/process/controllerdevice/MovingHorizonEstimationExample.java
@@ -1,0 +1,124 @@
+package neqsim.process.controllerdevice;
+
+import neqsim.process.measurementdevice.MeasurementDeviceBaseClass;
+
+/**
+ * Example showcasing the {@link ModelPredictiveController} with moving horizon estimation. The
+ * scenario mimics an electric heater whose true dynamics drift over time. The controller identifies
+ * the process gain, time constant and bias online to maintain accurate tracking.
+ */
+public class MovingHorizonEstimationExample {
+
+  /**
+   * Simple first-order process model acting as the transmitter for the MPC. The model permits
+   * adjustments to the underlying gain, time constant and ambient bias to emulate plant drift.
+   */
+  private static final class AdaptiveHeaterMeasurement extends MeasurementDeviceBaseClass {
+    private static final long serialVersionUID = 1L;
+    private double ambientTemperature;
+    private double timeConstant;
+    private double processGain;
+    private double temperature;
+
+    AdaptiveHeaterMeasurement(String name, double ambient, double timeConstant, double gain) {
+      super(name, "C");
+      this.ambientTemperature = ambient;
+      this.timeConstant = timeConstant;
+      this.processGain = gain;
+      this.temperature = ambient;
+    }
+
+    void advance(double controlSignal, double dt) {
+      double tau = Math.max(timeConstant, 1.0e-6);
+      double drivingForce = -(temperature - ambientTemperature) + processGain * controlSignal;
+      temperature += drivingForce * dt / tau;
+    }
+
+    void setProcessGain(double gain) {
+      this.processGain = gain;
+    }
+
+    void setTimeConstant(double timeConstant) {
+      this.timeConstant = timeConstant;
+    }
+
+    void setAmbientTemperature(double ambientTemperature) {
+      this.ambientTemperature = ambientTemperature;
+    }
+
+    @Override
+    public double getMeasuredValue() {
+      return temperature;
+    }
+
+    @Override
+    public double getMeasuredValue(String unit) {
+      if (unit == null || unit.isEmpty() || unit.equals(getUnit())) {
+        return temperature;
+      }
+      throw new IllegalArgumentException("Unsupported unit for adaptive heater measurement: " + unit);
+    }
+  }
+
+  private MovingHorizonEstimationExample() {}
+
+  public static void main(String[] args) {
+    double ambient = 18.0;
+    double initialGain = 0.55;
+    double initialTimeConstant = 45.0;
+    double dt = 1.0;
+
+    AdaptiveHeaterMeasurement measurement =
+        new AdaptiveHeaterMeasurement("adaptive heater", ambient, initialTimeConstant, initialGain);
+
+    ModelPredictiveController controller = new ModelPredictiveController("movingHorizonExample");
+    controller.setTransmitter(measurement);
+    controller.setControllerSetPoint(ambient + 22.0, "C");
+    controller.setProcessModel(0.2, 20.0);
+    controller.setProcessBias(ambient + 3.0);
+    controller.setPredictionHorizon(20);
+    controller.setWeights(1.0, 0.04, 0.2);
+    controller.setPreferredControlValue(0.0);
+    controller.setOutputLimits(0.0, 120.0);
+    controller.enableMovingHorizonEstimation(60);
+
+    for (int step = 0; step < 240; step++) {
+      controller.runTransient(controller.getResponse(), dt);
+      double control = controller.getResponse();
+      measurement.advance(control, dt);
+    }
+
+    ModelPredictiveController.MovingHorizonEstimate initialEstimate =
+        controller.getLastMovingHorizonEstimate();
+    if (initialEstimate != null) {
+      System.out.println("Initial identification: gain=" + initialEstimate.getProcessGain()
+          + ", tau=" + initialEstimate.getTimeConstant() + ", bias="
+          + initialEstimate.getProcessBias() + ", mse=" + initialEstimate.getMeanSquaredError());
+    }
+
+    double fouledGain = 0.35;
+    double fouledTimeConstant = 70.0;
+    double newAmbient = ambient + 4.0;
+    measurement.setProcessGain(fouledGain);
+    measurement.setTimeConstant(fouledTimeConstant);
+    measurement.setAmbientTemperature(newAmbient);
+    controller.setControllerSetPoint(newAmbient + 20.0, "C");
+
+    for (int step = 0; step < 260; step++) {
+      controller.runTransient(controller.getResponse(), dt);
+      double control = controller.getResponse();
+      measurement.advance(control, dt);
+    }
+
+    ModelPredictiveController.MovingHorizonEstimate adaptedEstimate =
+        controller.getLastMovingHorizonEstimate();
+    if (adaptedEstimate != null) {
+      System.out.println("Adapted identification: gain=" + adaptedEstimate.getProcessGain()
+          + ", tau=" + adaptedEstimate.getTimeConstant() + ", bias="
+          + adaptedEstimate.getProcessBias() + ", mse=" + adaptedEstimate.getMeanSquaredError());
+    }
+
+    System.out.println("Final measured temperature: " + measurement.getMeasuredValue());
+    System.out.println("Controller set point: " + controller.getControllerSetPoint());
+  }
+}

--- a/examples/neqsim/process/controllerdevice/ProcessControlExample.java
+++ b/examples/neqsim/process/controllerdevice/ProcessControlExample.java
@@ -1,0 +1,127 @@
+package neqsim.process.controllerdevice;
+
+import java.util.UUID;
+import neqsim.process.controllerdevice.structure.CascadeControllerStructure;
+import neqsim.process.controllerdevice.structure.FeedForwardControllerStructure;
+import neqsim.process.controllerdevice.structure.RatioControllerStructure;
+import neqsim.process.equipment.separator.Separator;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.equipment.valve.ThrottlingValve;
+import neqsim.process.measurementdevice.MeasurementDeviceBaseClass;
+import neqsim.process.measurementdevice.MeasurementDeviceInterface;
+import neqsim.process.measurementdevice.VolumeFlowTransmitter;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+
+/**
+ * Example mirroring the process-control integration test. It shows how to wire
+ * transmitters, PID controllers and controller structures to a simple process.
+ */
+public class ProcessControlExample {
+
+  /** Transmitter returning the current valve opening. */
+  static class ValvePositionTransmitter extends MeasurementDeviceBaseClass {
+    private static final long serialVersionUID = 1L;
+    private final ThrottlingValve valve;
+
+    ValvePositionTransmitter(String name, ThrottlingValve valve) {
+      super(name, "%");
+      this.valve = valve;
+    }
+
+    @Override
+    public double getMeasuredValue() {
+      return valve.getPercentValveOpening();
+    }
+
+    @Override
+    public double getMeasuredValue(String unit) {
+      return getMeasuredValue();
+    }
+  }
+
+  private ProcessControlExample() {}
+
+  public static void main(String[] args) {
+    // Create a simple gas process: feed stream -> valve -> separator
+    SystemInterface gas = new neqsim.thermo.system.SystemSrkEos(298.15, 10.0);
+    gas.addComponent("methane", 0.9);
+    gas.addComponent("ethane", 0.1);
+    gas.createDatabase(true);
+    gas.setMixingRule(2);
+
+    Stream feed = new Stream("feed", gas);
+    feed.setFlowRate(100.0, "kg/hr");
+    feed.setPressure(10.0, "bara");
+
+    ThrottlingValve valve = new ThrottlingValve("valve", feed);
+    valve.setOutletPressure(5.0);
+    valve.setCalculateSteadyState(false);
+
+    Separator sep = new Separator("sep");
+    sep.addStream(valve.getOutletStream());
+    sep.setCalculateSteadyState(false);
+
+    // Measurement device with noise and delay to mimic a realistic transmitter
+    VolumeFlowTransmitter flowMeas = new VolumeFlowTransmitter(sep.getGasOutStream());
+    flowMeas.setUnit("kg/hr");
+    flowMeas.setNoiseStdDev(1.0);
+    flowMeas.setDelaySteps(1);
+    flowMeas.setRandomSeed(0);
+    flowMeas.setMaximumValue(200.0);
+    flowMeas.setMinimumValue(0.0);
+
+    // PID controller acting on valve opening
+    ControllerDeviceBaseClass flowController = new ControllerDeviceBaseClass("flow");
+    flowController.setTransmitter(flowMeas);
+    flowController.setControllerSetPoint(120.0, "kg/hr");
+    flowController.setOutputLimits(0.0, 100.0);
+    flowController.setDerivativeFilterTime(1.0);
+    flowController.autoTuneStepResponse(1.0, 10.0, 2.0);
+    flowController.addGainSchedulePoint(80.0, flowController.getKp(), flowController.getTi(),
+        flowController.getTd());
+    flowController.addGainSchedulePoint(120.0, flowController.getKp() * 0.5, flowController.getTi(),
+        flowController.getTd());
+    flowController.resetEventLog();
+    flowController.resetPerformanceMetrics();
+
+    valve.setController(flowController);
+
+    ProcessSystem sys = new ProcessSystem();
+    sys.add(feed);
+    sys.add(valve);
+    sys.add(sep);
+    sys.add(flowMeas);
+    sys.run();
+
+    // Run controller iterations with noise and delay in measurements
+    for (int i = 0; i < 20; i++) {
+      flowController.runTransient(flowController.getResponse(), 1.0, UUID.randomUUID());
+    }
+
+    System.out.println("Flow controller response after iterations: " + flowController.getResponse());
+    System.out.println("Events captured: " + flowController.getEventLog().size());
+
+    // Demonstrate cascade, ratio and feed-forward structures
+    ControllerDeviceBaseClass secondary = new ControllerDeviceBaseClass("position");
+    MeasurementDeviceInterface posTrans = new ValvePositionTransmitter("pos", valve);
+    secondary.setTransmitter(posTrans);
+    secondary.setControllerParameters(1.0, 1.0, 0.0);
+    CascadeControllerStructure cascade = new CascadeControllerStructure(flowController, secondary);
+    cascade.runTransient(1.0);
+
+    VolumeFlowTransmitter feedMeas = new VolumeFlowTransmitter(feed);
+    feedMeas.setUnit("kg/hr");
+    RatioControllerStructure ratio = new RatioControllerStructure(flowController, feedMeas);
+    ratio.setRatio(0.8);
+    ratio.runTransient(1.0);
+
+    FeedForwardControllerStructure ff = new FeedForwardControllerStructure(flowController, feedMeas);
+    ff.setFeedForwardGain(0.1);
+    ff.runTransient(1.0);
+
+    System.out.println("Cascade output: " + cascade.getOutput());
+    System.out.println("Ratio output: " + ratio.getOutput());
+    System.out.println("Feed-forward output: " + ff.getOutput());
+  }
+}

--- a/examples/neqsim/process/measurementdevice/CombustionEmissionsCalculatorExample.java
+++ b/examples/neqsim/process/measurementdevice/CombustionEmissionsCalculatorExample.java
@@ -1,0 +1,33 @@
+package neqsim.process.measurementdevice;
+
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Demonstrates calculating combustion emissions from a fuel gas stream.
+ */
+public class CombustionEmissionsCalculatorExample {
+
+  private CombustionEmissionsCalculatorExample() {}
+
+  public static void main(String[] args) {
+    SystemInterface fuelGas = new SystemSrkEos(190, 10);
+    fuelGas.addComponent("nitrogen", 0.01);
+    fuelGas.addComponent("CO2", 0.01);
+    fuelGas.addComponent("methane", 1.0);
+    fuelGas.addComponent("ethane", 0.05);
+    fuelGas.addComponent("propane", 0.01);
+    fuelGas.addComponent("n-butane", 0.001);
+    fuelGas.addComponent("i-butane", 0.001);
+
+    Stream feedStream = new Stream("fuel gas", fuelGas);
+    feedStream.setFlowRate(1.0, "kg/hr");
+    feedStream.run();
+
+    CombustionEmissionsCalculator emissionsCalc =
+        new CombustionEmissionsCalculator("emissions", feedStream);
+    double emissions = emissionsCalc.getMeasuredValue("kg/hr");
+    System.out.println("Total combustion emissions: " + emissions + " kg/hr");
+  }
+}

--- a/examples/neqsim/process/measurementdevice/HydrocarbonDewPointAnalyserExample.java
+++ b/examples/neqsim/process/measurementdevice/HydrocarbonDewPointAnalyserExample.java
@@ -1,0 +1,38 @@
+package neqsim.process.measurementdevice;
+
+import neqsim.process.equipment.stream.Stream;
+import neqsim.process.processmodel.ProcessSystem;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+
+/**
+ * Example illustrating how to compute hydrocarbon dew point using the analyser utility.
+ */
+public class HydrocarbonDewPointAnalyserExample {
+
+  private HydrocarbonDewPointAnalyserExample() {}
+
+  public static void main(String[] args) {
+    SystemInterface thermoSystem = new SystemSrkEos(298.0, 50.0);
+    thermoSystem.addComponent("methane", 1.0);
+    thermoSystem.addComponent("ethane", 0.1);
+    thermoSystem.addComponent("propane", 0.1);
+    thermoSystem.addComponent("i-butane", 0.001);
+    thermoSystem.addComponent("n-butane", 0.001);
+    thermoSystem.addComponent("i-pentane", 0.001);
+    thermoSystem.addComponent("n-pentane", 0.0001);
+    thermoSystem.setMixingRule("classic");
+
+    Stream stream = new Stream("gas stream", thermoSystem);
+    HydrocarbonDewPointAnalyser analyser = new HydrocarbonDewPointAnalyser("dew point", stream);
+
+    ProcessSystem process = new ProcessSystem();
+    process.add(stream);
+    process.add(analyser);
+    process.run();
+
+    analyser.setReferencePressure(40.0);
+    double dewPointC = analyser.getMeasuredValue("C");
+    System.out.println("Hydrocarbon dew point at 40 bara: " + dewPointC + " C");
+  }
+}

--- a/examples/neqsim/thermo/FluidCreationExample.java
+++ b/examples/neqsim/thermo/FluidCreationExample.java
@@ -1,0 +1,22 @@
+package neqsim.thermo;
+
+/** Simple examples demonstrating the {@link FluidCreator} helper methods. */
+public class FluidCreationExample {
+
+  private FluidCreationExample() {}
+
+  public static void main(String[] args) {
+    String[] componentNames = new String[] {"methane", "ethane"};
+    System.out.println("Creating fluid from component names...");
+    FluidCreator.create(componentNames);
+
+    String fluidType = "air";
+    System.out.println("Creating predefined fluid type: " + fluidType);
+    FluidCreator.create(fluidType);
+
+    double[] rate = new double[] {1.0, 1.0};
+    String unit = "kg/sec";
+    System.out.println("Creating fluid with specified component flowrates...");
+    FluidCreator.create(componentNames, rate, unit);
+  }
+}

--- a/examples/neqsim/thermodynamicoperations/ThermodynamicFlashExample.java
+++ b/examples/neqsim/thermodynamicoperations/ThermodynamicFlashExample.java
@@ -1,0 +1,63 @@
+package neqsim.thermodynamicoperations;
+
+import java.util.Arrays;
+import neqsim.api.ioc.CalculationResult;
+import neqsim.thermo.system.SystemInterface;
+import neqsim.thermo.system.SystemSrkEos;
+import neqsim.thermodynamicoperations.ThermodynamicOperations.FlashType;
+
+/**
+ * Example illustrating common flash and property calculation scenarios from the test suite.
+ */
+public class ThermodynamicFlashExample {
+
+  private ThermodynamicFlashExample() {}
+
+  public static void main(String[] args) {
+    runSimpleFlash();
+    runDefinedFluidPropertyFlash();
+  }
+
+  private static void runSimpleFlash() {
+    SystemInterface thermoSystem = new SystemSrkEos(280.0, 10.0);
+    thermoSystem.addComponent("methane", 0.7);
+    thermoSystem.addComponent("ethane", 0.3);
+    ThermodynamicOperations ops = new ThermodynamicOperations(thermoSystem);
+
+    double pressure = 10.0;
+    double temperature = 20.0;
+    ops.flash(FlashType.PT, pressure, temperature, "bara", "C");
+    ops.getSystem().init(2);
+    ops.getSystem().initPhysicalProperties();
+    Double[] ptFluidProperties = ops.getSystem().getProperties().getValues();
+
+    ops.getSystem().init(0);
+    ops.flash(FlashType.TP, temperature, pressure, "C", "bara");
+    ops.getSystem().init(2);
+    ops.getSystem().initPhysicalProperties();
+    Double[] tpFluidProperties = ops.getSystem().getProperties().getValues();
+
+    System.out.println("PT flash properties: " + Arrays.toString(ptFluidProperties));
+    System.out.println("TP flash properties: " + Arrays.toString(tpFluidProperties));
+  }
+
+  private static void runDefinedFluidPropertyFlash() {
+    Double[] sp1 = new Double[] {22.1, 23.2, 24.23, 25.98, 25.23, 26.1, 27.3, 28.7, 23.5, 22.7};
+    Double[] sp2 = new Double[] {288.1, 290.1, 295.1, 301.2, 299.3, 310.2, 315.3, 310.0, 305.2, 312.7};
+
+    SystemInterface fluid = new SystemSrkEos(273.15 + 45.0, 22.0);
+    fluid.addComponent("nitrogen", 0.79);
+    fluid.addComponent("oxygen", 0.21);
+    fluid.setMixingRule(2);
+    fluid.useVolumeCorrection(true);
+    fluid.setMultiPhaseCheck(true);
+
+    ThermodynamicOperations fluidOps = new ThermodynamicOperations(fluid);
+    CalculationResult res = fluidOps.propertyFlash(Arrays.asList(sp1), Arrays.asList(sp2), 1,
+        Arrays.asList("O2", "N2"), Arrays.asList(Arrays.asList(98.0, 98.0, 98.0, 98.0, 98.0,
+            98.0, 98.0, 98.0, 98.0, 98.0), Arrays.asList(2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0,
+                2.0, 2.0)));
+
+    System.out.println("Property flash calculation errors: " + Arrays.toString(res.calculationError));
+  }
+}


### PR DESCRIPTION
## Summary
- add chemical reaction equilibrium example derived from combustion test
- add measurement device examples for hydrocarbon dew point and combustion emissions
- compile project and run example main classes to validate they execute

## Testing
- mvn -DskipTests compile
- javac -d target/examples -cp "$(cat target/classpath.txt):target/classes:target/test-classes" $(find examples -name "*.java")
- java -cp "$CLASSPATH" neqsim.thermo.FluidCreationExample
- java -cp "$CLASSPATH" neqsim.thermodynamicoperations.ThermodynamicFlashExample
- java -cp "$CLASSPATH" neqsim.process.controllerdevice.ProcessControlExample
- java -cp "$CLASSPATH" neqsim.process.controllerdevice.MovingHorizonEstimationExample
- java -cp "$CLASSPATH" neqsim.chemicalreactions.ChemicalEquilibriumExample
- java -cp "$CLASSPATH" neqsim.process.measurementdevice.HydrocarbonDewPointAnalyserExample
- java -cp "$CLASSPATH" neqsim.process.measurementdevice.CombustionEmissionsCalculatorExample

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fdf056324832d9d55e6cf7fc5362e)