### PR TITLE
Document project structure for contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,3 +63,20 @@ Checkstyle, SpotBugs, and PMD run as part of the Maven build to catch formatting
 ```
 
 These checks are configured not to fail the build by default, but contributions should address any reported problems.
+
+## Project structure and package layout
+
+Most contributions will need to add production code, automated tests, and possibly supporting resources. The high-level layout is:
+
+* **Production code:** place Java sources under `src/main/java` following the existing package hierarchy (for example, `com.equinor.neqsim.thermo` or `com.equinor.neqsim.processsimulation`). Each directory boundary should map cleanly to a cohesive module (e.g., `thermo`, `physicalproperties`, `processsimulation`).
+* **Automated tests:** place JUnit tests under `src/test/java`, mirroring the package of the code under test. Keep small test fixtures in `src/test/resources` alongside the relevant package path when possible.
+* **Shared resources:** non-test resources that ship with the library belong in `src/main/resources`. Larger sample data or notebooks should go to `data/`, `examples/`, or `notebooks/` depending on audience and usage.
+
+### Package naming and boundaries
+
+* Use the `com.equinor.neqsim` root, followed by the functional area. For example: `com.equinor.neqsim.thermo` for thermodynamics routines, `com.equinor.neqsim.processsimulation` for unit operations and flowsheets, and `com.equinor.neqsim.physicalproperties` for transport properties.
+* Avoid creating deep or overlapping packages when an existing boundary fits. Prefer adding to an established module (`thermo`, `physicalproperties`, `processsimulation`, `chemicalreactions`, `parameterfitting`) instead of inventing a parallel hierarchy.
+* Keep utilities that are reused across modules in clearly named subpackages such as `com.equinor.neqsim.util.*` so that domain packages remain focused.
+* Examples, demos, and notebooks should stay out of the production package tree. Use `examples/` for runnable samples and `notebooks/` for exploratory work.
+
+For a concise overview of where to place new files, see [docs/contributing-structure.md](docs/contributing-structure.md).

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ See the [getting started as a NeqSim developer](https://github.com/equinor/neqsi
 See [docs/DEVELOPER_SETUP.md](docs/DEVELOPER_SETUP.md) for a summary of how to clone the project, build it and run the tests. For more details see the [getting started as a NeqSim developer](https://github.com/equinor/neqsim/wiki/Getting-started-as-a-NeqSim-developer) documentation. Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests. An interactive demonstration of how to get started as a NeqSim developer is presented in this [NeqSim Colab demo](https://colab.research.google.com/drive/1JiszeCxfpcJZT2vejVWuNWGmd9SJdNC7).
 Pull requests will only be accepted if all tests and `./mvnw checkstyle:check` pass.
 
+For guidance on where to place production code, tests, and resources, see [docs/contributing-structure.md](docs/contributing-structure.md).
+
 ## Discussion forum
 
 Questions related to neqsim can be posted in the [github discussion pages](https://github.com/equinor/neqsim/discussions).

--- a/docs/contributing-structure.md
+++ b/docs/contributing-structure.md
@@ -1,0 +1,28 @@
+# Repository layout quick reference
+
+Use this guide to place new files consistently across the repository.
+
+## Production code
+
+* Java sources live under `src/main/java` and follow the `com.equinor.neqsim` package root.
+* Keep contributions inside the established functional modules:
+  * `com.equinor.neqsim.thermo` – thermodynamic routines.
+  * `com.equinor.neqsim.physicalproperties` – transport and thermophysical property models.
+  * `com.equinor.neqsim.processsimulation` – unit operations, process models, and flowsheet orchestration.
+  * `com.equinor.neqsim.chemicalreactions` – equilibrium and kinetic reactions.
+  * `com.equinor.neqsim.parameterfitting` – parameter estimation tools.
+* Shared helpers can go in `com.equinor.neqsim.util.*` when they are not domain-specific.
+* Avoid inventing parallel hierarchies; extend the closest existing module instead.
+
+## Tests
+
+* Place JUnit tests in `src/test/java`, mirroring the package of the code under test.
+* Small fixtures and golden files belong in `src/test/resources` within the same package path.
+* Integration-style examples that demonstrate APIs should stay in `examples/` rather than under `src/test/java`.
+
+## Resources and data
+
+* Runtime resources (configuration templates, lookup tables) belong in `src/main/resources`.
+* Test-only resources go in `src/test/resources`.
+* Larger datasets or notebooks should live in `data/` or `notebooks/` to keep the packaged library lean.
+* Runnable samples and tutorial code belong in `examples/` and should avoid depending on internal test fixtures.


### PR DESCRIPTION
## Summary
- add contributor quick reference for placing production code, tests, and resources
- expand contributing guidelines with package naming and module boundary expectations
- link README to the new structure guidance for discoverability

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941207f39ac832d8b6f4b186154d945)