### PR TITLE
Fix Javadoc HTML entity in FrictionTheoryViscosityMethod

### DIFF
--- a/src/main/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/viscosity/FrictionTheoryViscosityMethod.java
+++ b/src/main/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/viscosity/FrictionTheoryViscosityMethod.java
@@ -16,7 +16,7 @@ import neqsim.thermo.phase.PhasePrEos;
  * Quiñones-Cisneros, R., and Firoozabadi, A. (2000). Friction theory for the viscosity of fluids.
  * AIChE Journal, 46(4), 16–23.
  * Chung, T.-H., Ajlan, M., Lee, L. L., and Starling, K. E. (1988). Generalized multiparameter
- * correlation for nonpolar and polar fluid transport properties. Industrial & Engineering Chemistry
+ * correlation for nonpolar and polar fluid transport properties. Industrial &amp; Engineering Chemistry
  * Research, 27(4), 671–679.
  * Wilke, C. R. (1950). A viscosity equation for gas mixtures. The Journal of Chemical Physics,
  * 18(4), 517–519.


### PR DESCRIPTION
### Motivation
- Javadoc generation failed with a `bad HTML entity` error due to an unescaped ampersand in the reference text of `FrictionTheoryViscosityMethod.java`.

### Description
- Replace `Industrial & Engineering Chemistry` with `Industrial &amp; Engineering Chemistry` in the Javadoc of `src/main/java/neqsim/physicalproperties/methods/commonphasephysicalproperties/viscosity/FrictionTheoryViscosityMethod.java` to produce valid HTML.

### Testing
- Ran `./mvnw -q -DskipTests javadoc:javadoc` and confirmed Javadoc generation completes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d696f38d90832db6b2e3b550a1621f)