### PR TITLE
Fix whitespace handling in ProcessSystem stream references

### DIFF
--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -3931,16 +3931,17 @@ public class ProcessSystem extends SimulationBaseClass {
     if (ref == null || ref.trim().isEmpty()) {
       return null;
     }
+    String normalizedRef = ref.trim();
 
     String unitName;
     String port = "outlet";
 
-    if (ref.contains(".")) {
-      String[] parts = ref.split("\\.", 2);
-      unitName = parts[0];
-      port = parts[1].toLowerCase();
+    if (normalizedRef.contains(".")) {
+      String[] parts = normalizedRef.split("\\.", 2);
+      unitName = parts[0].trim();
+      port = parts[1].trim().toLowerCase();
     } else {
-      unitName = ref;
+      unitName = normalizedRef;
     }
 
     ProcessEquipmentInterface unit = getUnit(unitName);

--- a/src/test/java/neqsim/process/processmodel/JsonProcessBuilderTest.java
+++ b/src/test/java/neqsim/process/processmodel/JsonProcessBuilderTest.java
@@ -66,6 +66,28 @@ class JsonProcessBuilderTest {
   }
 
   @Test
+  void testBuildWithWhitespaceAroundStreamReference() {
+    SystemSrkEos fluid = new SystemSrkEos(298.15, 50.0);
+    fluid.addComponent("methane", 0.85);
+    fluid.addComponent("ethane", 0.10);
+    fluid.addComponent("propane", 0.05);
+    fluid.setMixingRule("classic");
+
+    Stream feed = new Stream("feed", fluid);
+    neqsim.process.equipment.separator.Separator separator =
+        new neqsim.process.equipment.separator.Separator("HP Sep", feed);
+    ProcessSystem process = new ProcessSystem();
+    process.add(feed);
+    process.add(separator);
+
+    assertNotNull(process.resolveStreamReference("  feed  "),
+        "resolveStreamReference should trim whitespace for plain stream names");
+    StreamInterface gasOutWithWhitespace = process.resolveStreamReference("  HP Sep. gasOut  ");
+    assertNotNull(gasOutWithWhitespace,
+        "resolveStreamReference should trim whitespace around unit and port tokens");
+  }
+
+  @Test
   void testBuildWithMultipleFluids() {
     String json = "{" + "\"fluids\": {" + "  \"gas\": {" + "    \"model\": \"SRK\","
         + "    \"temperature\": 298.15," + "    \"pressure\": 50.0,"


### PR DESCRIPTION
### Motivation
- `ProcessSystem.resolveStreamReference` accepted a reference string but only checked `trim()` for emptiness while still parsing the original untrimmed input, causing valid references with surrounding spaces (e.g. `"  feed  "` or `"  HP Sep. gasOut  "`) to fail resolution and produce wiring warnings or missing connections.
- Users and JSON process definitions can easily include incidental whitespace; resolving these gracefully improves robustness of the JSON process builder and wiring logic.

### Description
- Normalize and trim the incoming reference at the start of `resolveStreamReference` and use `normalizedRef` for parsing.  
- Trim both unit and port tokens when splitting dot-notation references (e.g. `unitName.port`) so `"  HP Sep. gasOut  "` resolves correctly.  
- Added a regression test `testBuildWithWhitespaceAroundStreamReference` to `JsonProcessBuilderTest` that constructs a minimal `ProcessSystem` (a `Stream` + `Separator`) and asserts `resolveStreamReference` handles whitespace for plain and dot-notation references.
- Committed the changes and updated the test sources to exercise `resolveStreamReference` directly.

### Testing
- Ran the targeted unit test: `./mvnw -q -Dtest=JsonProcessBuilderTest#testBuildWithWhitespaceAroundStreamReference test` which passed after the fix.  
- Executed the full test class with `./mvnw -q -Dtest=JsonProcessBuilderTest test` and confirmed the test class passed without failures.  
- The change is limited to parsing and unit tests; no other automated checks were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69dd706c8832db618a088c5eabe1c)