### PR TITLE
Add JSON process schema docs, validator, and explicit connections support

### DIFF
--- a/docs/process/json_process_models_and_systems.md
+++ b/docs/process/json_process_models_and_systems.md
@@ -1,0 +1,294 @@
+---
+title: JSON Format for ProcessSystem and ProcessModel
+description: Accurate reference for NeqSim JSON process builder input, validation, and large flowsheet setup with mixers, splitters, and recycles.
+---
+
+# JSON Format for ProcessSystem and ProcessModel
+
+This page documents the **actual JSON format** consumed by `ProcessSystem.fromJson(...)` and
+`ProcessSystem.fromJsonAndRun(...)`.
+
+## Quick answer: is there a JSON verifier?
+
+Yes:
+
+- `ProcessSystem.validateJson(String json)`
+- `ProcessJsonValidator.validate(String json)`
+
+Use validation as a pre-flight check before calling `fromJson()` or `fromJsonAndRun()`.
+
+## 1. Root JSON structure (builder input)
+
+The builder expects a root object with these common keys:
+
+- `fluid` (optional): single default fluid definition
+- `fluids` (optional): named fluids map (for `fluidRef` on streams)
+- `process` (**required**): array of unit definitions
+- `autoRun` (optional): `true` to run immediately
+
+Minimal valid structure:
+
+```json
+{
+  "fluid": {
+    "model": "SRK",
+    "temperature": 298.15,
+    "pressure": 50.0,
+    "mixingRule": "classic",
+    "components": {
+      "methane": 0.85,
+      "ethane": 0.10,
+      "propane": 0.05
+    }
+  },
+  "process": [
+    {
+      "type": "Stream",
+      "name": "feed",
+      "properties": {
+        "flowRate": [50000.0, "kg/hr"]
+      }
+    }
+  ]
+}
+```
+
+> Important: current builder input uses `process` + `properties` + `inlet`/`inlets` patterns.
+
+## 2. Unit definition format
+
+Each object in `process` should include:
+
+- `type` (required)
+- `name` (strongly recommended and should be unique)
+- wiring fields depending on unit type:
+  - `inlet`: single reference string
+  - `inlets`: array of reference strings
+- `properties` object for operating conditions and setpoints
+
+Example:
+
+```json
+{
+  "type": "Compressor",
+  "name": "Comp",
+  "inlet": "HP Sep.gasOut",
+  "properties": {
+    "outletPressure": [80.0, "bara"]
+  }
+}
+```
+
+## 3. Stream addressing and ports
+
+References are by unit name, optionally with port suffix:
+
+- `"feed"` (stream unit)
+- `"HP Sep.gasOut"`
+- `"HP Sep.liquidOut"`
+- `"Comp.out"` / `"Comp.outStream"`
+
+The resolver trims surrounding whitespace.
+
+## 4. Large process JSON example (splitter + mixer + recycle)
+
+```json
+{
+  "fluid": {
+    "model": "SRK",
+    "temperature": 298.15,
+    "pressure": 70.0,
+    "mixingRule": "classic",
+    "components": {
+      "methane": 0.88,
+      "ethane": 0.08,
+      "propane": 0.04
+    }
+  },
+  "autoRun": true,
+  "process": [
+    {"type": "Stream", "name": "feed", "properties": {"flowRate": [250000.0, "kg/hr"]}},
+
+    {"type": "Splitter", "name": "Feed Splitter", "inlet": "feed",
+      "properties": {"splitFactors": [0.60, 0.40]}},
+
+    {"type": "Cooler", "name": "Train A Cooler", "inlet": "Feed Splitter.splitStream_0",
+      "properties": {"outTemperature": [20.0, "C"]}},
+
+    {"type": "ThrottlingValve", "name": "Train B Valve", "inlet": "Feed Splitter.splitStream_1",
+      "properties": {"outletPressure": [65.0, "bara"]}},
+
+    {"type": "Mixer", "name": "Combined Mixer",
+      "inlets": ["Train A Cooler.out", "Train B Valve.out"]},
+
+    {"type": "Separator", "name": "HP Sep", "inlet": "Combined Mixer.out"},
+
+    {"type": "Compressor", "name": "Recycle Comp", "inlet": "HP Sep.gasOut",
+      "properties": {"outletPressure": [72.0, "bara"]}},
+
+    {"type": "Recycle", "name": "Gas Recycle", "inlet": "Recycle Comp.out"},
+
+    {"type": "Mixer", "name": "Feed + Recycle",
+      "inlets": ["feed", "Gas Recycle.out"]}
+  ]
+}
+```
+
+### 4.1 Optional explicit `connections` metadata
+
+You can include a root-level `connections` array to persist explicit topology metadata.
+These are recorded on `ProcessSystem.getConnections()` and are useful for interchange,
+PFD export, and topology analysis.
+
+```json
+"connections": [
+  {"from": "feed", "to": "Sep", "sourcePort": "outlet", "targetPort": "inlet", "type": "MATERIAL"}
+]
+```
+
+Supported types map to `ProcessConnection.ConnectionType` values (`MATERIAL`, `ENERGY`, `SIGNAL`).
+Unknown types default to `MATERIAL` with a warning.
+
+## 5. Validation workflow (recommended)
+
+Java:
+
+```java
+String json = ...;
+ProcessJsonValidator.ValidationReport report = ProcessSystem.validateJson(json);
+if (!report.isValid()) {
+  throw new IllegalArgumentException("Invalid process JSON: " + report.getErrors());
+}
+SimulationResult result = ProcessSystem.fromJsonAndRun(json);
+```
+
+Python (via JPype wrapper):
+
+```python
+report = ns.ProcessSystem.validateJson(json_text)
+if not report.isValid():
+    raise ValueError(str(report.getErrors()))
+result = ns.ProcessSystem.fromJsonAndRun(json_text)
+```
+
+
+## 6. Importing E300 fluids (supported)
+
+The JSON builder supports loading fluid thermodynamics from Eclipse E300 data using
+`e300FilePath` in the `fluid` object.
+
+Example:
+
+```json
+{
+  "fluid": {
+    "model": "PR_LK",
+    "temperature": 310.15,
+    "pressure": 50.0,
+    "e300FilePath": "/absolute/path/to/fluid.e300"
+  },
+  "process": [
+    {"type": "Stream", "name": "feed", "properties": {"flowRate": [10000.0, "kg/hr"]}}
+  ]
+}
+```
+
+Notes:
+
+- When `e300FilePath` is provided, component properties and BIPs are sourced from the E300 file.
+- You can still validate the process structure with `ProcessSystem.validateJson(...)` before build/run.
+- For pre-built fluids from E300 workflows, use `ProcessSystem.fromJsonAndRun(json, fluid)`.
+
+## 7. What validator checks today
+
+Errors:
+- invalid JSON
+- missing `process` array
+- missing `type`
+- missing `name`
+- duplicate names
+
+Warnings:
+- inlet/inlets/streams input references that do not resolve to known unit/port names
+
+## 8. ProcessModel lifecycle JSON
+
+For lifecycle snapshots/versioning of full `ProcessModel` and `ProcessSystem` states,
+see:
+
+- `docs/process/lifecycle/process_model_lifecycle.md`
+- `docs/simulation/process_serialization.md`
+
+Builder input JSON (`fromJson`) and lifecycle snapshot JSON (`ProcessModelState`) have different purposes.
+
+
+## 9. Export and full JSON round-trip workflows
+
+### 9.1 Builder JSON round-trip (ProcessSystem -> JSON -> ProcessSystem)
+
+Use this for interoperability and API payloads.
+
+```java
+// Build or run a process
+ProcessSystem process = ...;
+process.run();
+
+// Export to builder JSON
+String json = process.toJson();
+
+// Rebuild from exported JSON
+SimulationResult rebuilt = ProcessSystem.fromJson(json);
+if (!rebuilt.isSuccess()) {
+  throw new RuntimeException(rebuilt.toString());
+}
+
+// Optional: run rebuilt process
+rebuilt.getProcessSystem().run();
+```
+
+Python pattern:
+
+```python
+json_text = process.toJson()
+rebuild = ns.ProcessSystem.fromJson(json_text)
+if not rebuild.isSuccess():
+    raise RuntimeError(str(rebuild))
+rebuilt_process = rebuild.getProcessSystem()
+rebuilt_process.run()
+```
+
+### 9.2 Lifecycle JSON round-trip (state snapshots)
+
+Use `ProcessSystemState` and `ProcessModelState` for Git-friendly model snapshots,
+versioning, comparison, and lifecycle workflows.
+
+```java
+// Single ProcessSystem snapshot
+ProcessSystemState state = ProcessSystemState.fromProcessSystem(process);
+state.saveToFile("model_state.json");
+ProcessSystemState loaded = ProcessSystemState.loadFromFile("model_state.json");
+ProcessSystem restored = loaded.toProcessSystem();
+
+// Multi-area ProcessModel snapshot
+ProcessModelState modelState = ProcessModelState.fromProcessModel(model);
+modelState.saveToFile("plant_state.json");
+ProcessModelState loadedModelState = ProcessModelState.loadFromFile("plant_state.json");
+ProcessModel restoredModel = loadedModelState.toProcessModel();
+```
+
+Choose the round-trip type by purpose:
+
+- `ProcessSystem.toJson()/fromJson(...)`: portable builder/execution JSON
+- `ProcessSystemState` / `ProcessModelState`: lifecycle state management JSON
+
+
+
+## 10. Coverage note
+
+Not every possible NeqSim feature is currently expressible in concise JSON form.
+The JSON builder supports the most commonly used process/equipment workflows, and
+coverage continues to evolve. For advanced behavior, you can:
+
+- build core topology from JSON, then refine in Java/Python API calls
+- export back using `process.toJson()` for traceability
+- use lifecycle snapshots (`ProcessSystemState`/`ProcessModelState`) for full-state persistence

--- a/docs/process/json_process_models_and_systems.md
+++ b/docs/process/json_process_models_and_systems.md
@@ -292,3 +292,50 @@ coverage continues to evolve. For advanced behavior, you can:
 - build core topology from JSON, then refine in Java/Python API calls
 - export back using `process.toJson()` for traceability
 - use lifecycle snapshots (`ProcessSystemState`/`ProcessModelState`) for full-state persistence
+
+
+
+## 11. JSON + optimization loop example (process + sizing variables)
+
+You can tune both process variables and equipment sizing variables directly from JSON payloads.
+A common pattern is:
+
+1. Optimizer proposes a payload (e.g., separator pressure + mechanical design knobs).
+2. Validate JSON with `ProcessSystem.validateJson(...)`.
+3. Build/run with `ProcessSystem.fromJsonAndRun(...)`.
+4. Evaluate objective (energy, CAPEX proxy, emissions, etc.).
+
+Example payload fragment:
+
+```json
+{
+  "process": [
+    {"type": "Separator", "name": "HP Sep", "inlet": "feed",
+      "properties": {
+        "pressure": [70.0, "bara"],
+        "mechanicalDesign": {
+          "gasLoadFactor": 0.107,
+          "retentionTime": 120.0,
+          "calcDesign": true
+        }
+      }
+    }
+  ]
+}
+```
+
+Python pseudo-loop:
+
+```python
+for candidate in candidates:
+    payload = make_payload(candidate)
+    report = ns.ProcessSystem.validateJson(payload)
+    if not report.isValid():
+        continue
+    result = ns.ProcessSystem.fromJsonAndRun(payload)
+    if not result.isSuccess():
+        continue
+    process = result.getProcessSystem()
+    # Example objective: combine process KPI + design KPI
+    score = objective(process)
+```

--- a/src/main/java/neqsim/process/processmodel/JsonProcessBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/JsonProcessBuilder.java
@@ -1016,8 +1016,38 @@ public class JsonProcessBuilder {
         applyEntrainment((Separator) equipment, entry.getValue());
         continue;
       }
+      if ("mechanicalDesign".equals(propName) && entry.getValue().isJsonObject()) {
+        applyMechanicalDesignProperties(equipment, entry.getValue().getAsJsonObject());
+        continue;
+      }
       JsonElement value = entry.getValue();
       applyProperty(equipment, propName, value);
+    }
+  }
+
+  private void applyMechanicalDesignProperties(ProcessEquipmentInterface equipment, JsonObject mdProps) {
+    try {
+      equipment.initMechanicalDesign();
+      Object design = equipment.getMechanicalDesign();
+      if (design == null) {
+        warnings.add("Mechanical design not available for " + equipment.getName());
+        return;
+      }
+      for (Map.Entry<String, JsonElement> entry : mdProps.entrySet()) {
+        String key = entry.getKey();
+        if ("calcDesign".equalsIgnoreCase(key) || "readDesignSpecifications".equalsIgnoreCase(key)) {
+          continue;
+        }
+        applyPropertyObject(design, equipment.getName(), key, entry.getValue());
+      }
+      if (mdProps.has("readDesignSpecifications") && mdProps.get("readDesignSpecifications").getAsBoolean()) {
+        invokeNoArg(design, equipment.getName(), "readDesignSpecifications");
+      }
+      if (mdProps.has("calcDesign") && mdProps.get("calcDesign").getAsBoolean()) {
+        invokeNoArg(design, equipment.getName(), "calcDesign");
+      }
+    } catch (Exception e) {
+      warnings.add("Error applying mechanicalDesign on " + equipment.getName() + ": " + e.getMessage());
     }
   }
 
@@ -1131,6 +1161,11 @@ public class JsonProcessBuilder {
    */
   private void applyProperty(ProcessEquipmentInterface equipment, String propName,
       JsonElement value) {
+    applyPropertyObject(equipment, equipment.getName(), propName, value);
+  }
+
+  private void applyPropertyObject(Object target, String targetName, String propName,
+      JsonElement value) {
     String setterName = "set" + Character.toUpperCase(propName.charAt(0)) + propName.substring(1);
 
     try {
@@ -1141,37 +1176,45 @@ public class JsonProcessBuilder {
           double numValue = arr.get(0).getAsDouble();
           String unit = arr.get(1).getAsString();
           java.lang.reflect.Method method =
-              equipment.getClass().getMethod(setterName, double.class, String.class);
-          method.invoke(equipment, numValue, unit);
+              target.getClass().getMethod(setterName, double.class, String.class);
+          method.invoke(target, numValue, unit);
         }
       } else if (value.isJsonPrimitive()) {
         if (value.getAsJsonPrimitive().isNumber()) {
           // Try double setter first
           try {
             java.lang.reflect.Method method =
-                equipment.getClass().getMethod(setterName, double.class);
-            method.invoke(equipment, value.getAsDouble());
+                target.getClass().getMethod(setterName, double.class);
+            method.invoke(target, value.getAsDouble());
           } catch (NoSuchMethodException e) {
             // Try int setter
-            java.lang.reflect.Method method = equipment.getClass().getMethod(setterName, int.class);
-            method.invoke(equipment, value.getAsInt());
+            java.lang.reflect.Method method = target.getClass().getMethod(setterName, int.class);
+            method.invoke(target, value.getAsInt());
           }
         } else if (value.getAsJsonPrimitive().isBoolean()) {
           java.lang.reflect.Method method =
-              equipment.getClass().getMethod(setterName, boolean.class);
-          method.invoke(equipment, value.getAsBoolean());
+              target.getClass().getMethod(setterName, boolean.class);
+          method.invoke(target, value.getAsBoolean());
         } else if (value.getAsJsonPrimitive().isString()) {
           java.lang.reflect.Method method =
-              equipment.getClass().getMethod(setterName, String.class);
-          method.invoke(equipment, value.getAsString());
+              target.getClass().getMethod(setterName, String.class);
+          method.invoke(target, value.getAsString());
         }
       }
     } catch (NoSuchMethodException e) {
-      warnings.add("Property '" + propName + "' not found on " + equipment.getName() + " (tried "
+      warnings.add("Property '" + propName + "' not found on " + targetName + " (tried "
           + setterName + ")");
     } catch (Exception e) {
-      warnings.add(
-          "Error setting '" + propName + "' on " + equipment.getName() + ": " + e.getMessage());
+      warnings.add("Error setting '" + propName + "' on " + targetName + ": " + e.getMessage());
+    }
+  }
+
+  private void invokeNoArg(Object target, String targetName, String methodName) {
+    try {
+      java.lang.reflect.Method method = target.getClass().getMethod(methodName);
+      method.invoke(target);
+    } catch (Exception e) {
+      warnings.add("Error invoking '" + methodName + "' on " + targetName + ": " + e.getMessage());
     }
   }
 

--- a/src/main/java/neqsim/process/processmodel/JsonProcessBuilder.java
+++ b/src/main/java/neqsim/process/processmodel/JsonProcessBuilder.java
@@ -260,6 +260,38 @@ public class JsonProcessBuilder {
       namedEquipment.remove(removeName);
     }
 
+
+
+    // Step 2b: Optional explicit topology metadata connections
+    if (root.has("connections") && root.get("connections").isJsonArray()) {
+      JsonArray connectionsArray = root.getAsJsonArray("connections");
+      for (int i = 0; i < connectionsArray.size(); i++) {
+        try {
+          JsonObject conn = connectionsArray.get(i).getAsJsonObject();
+          String from = conn.has("from") ? conn.get("from").getAsString() : null;
+          String to = conn.has("to") ? conn.get("to").getAsString() : null;
+          if (from == null || to == null || from.trim().isEmpty() || to.trim().isEmpty()) {
+            warnings.add("Skipping connections[" + i + "] - requires non-empty 'from' and 'to'");
+            continue;
+          }
+          String sourcePort = conn.has("sourcePort") ? conn.get("sourcePort").getAsString() : "outlet";
+          String targetPort = conn.has("targetPort") ? conn.get("targetPort").getAsString() : "inlet";
+          ProcessConnection.ConnectionType type = ProcessConnection.ConnectionType.MATERIAL;
+          if (conn.has("type")) {
+            try {
+              type = ProcessConnection.ConnectionType.valueOf(conn.get("type").getAsString().toUpperCase());
+            } catch (Exception ex) {
+              warnings.add("connections[" + i + "] has unknown type '" + conn.get("type").getAsString()
+                  + "' - defaulting to MATERIAL");
+            }
+          }
+          process.connect(from, sourcePort, to, targetPort, type);
+        } catch (Exception ex) {
+          warnings.add("Failed to parse connections[" + i + "]: " + ex.getMessage());
+        }
+      }
+    }
+
     // Step 4: Optionally run
     boolean autoRun = root.has("autoRun") && root.get("autoRun").getAsBoolean();
     if (autoRun) {

--- a/src/main/java/neqsim/process/processmodel/ProcessJsonValidator.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessJsonValidator.java
@@ -1,0 +1,132 @@
+package neqsim.process.processmodel;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/** Validates JSON process definitions before building/running simulations. */
+public final class ProcessJsonValidator {
+  private ProcessJsonValidator() {}
+
+  public static ValidationReport validate(String json) {
+    ValidationReport report = new ValidationReport();
+    if (json == null || json.trim().isEmpty()) {
+      report.addError("JSON input is null or empty");
+      return report;
+    }
+
+    JsonObject root;
+    try {
+      root = JsonParser.parseString(json).getAsJsonObject();
+    } catch (Exception ex) {
+      report.addError("JSON parse error: " + ex.getMessage());
+      return report;
+    }
+
+    if (!root.has("process") || !root.get("process").isJsonArray()) {
+      report.addError("Missing required 'process' array");
+      return report;
+    }
+
+    JsonArray process = root.getAsJsonArray("process");
+    Set<String> names = new HashSet<String>();
+    Set<String> validRefs = new HashSet<String>();
+
+    for (int i = 0; i < process.size(); i++) {
+      JsonObject unit = process.get(i).getAsJsonObject();
+      String type = getString(unit, "type");
+      String name = getString(unit, "name");
+
+      if (type == null || type.trim().isEmpty()) {
+        report.addError("process[" + i + "] is missing required field 'type'");
+      }
+      if (name == null || name.trim().isEmpty()) {
+        report.addError("process[" + i + "] is missing required field 'name'");
+        name = "unnamed_" + i;
+      }
+      if (names.contains(name)) {
+        report.addError("Duplicate unit name: '" + name + "'");
+      }
+      names.add(name);
+      validRefs.add(name);
+      validRefs.add(name + ".out");
+      validRefs.add(name + ".outStream");
+      validRefs.add(name + ".gasOut");
+      validRefs.add(name + ".liquidOut");
+      validRefs.add(name + ".gasOutStream");
+      validRefs.add(name + ".liquidOutStream");
+      validRefs.add(name + ".splitStream_0");
+      validRefs.add(name + ".splitStream_1");
+    }
+
+    for (int i = 0; i < process.size(); i++) {
+      JsonObject unit = process.get(i).getAsJsonObject();
+      validateReferenceField(report, validRefs, unit, i, "inlet");
+      if (unit.has("inlets") && unit.get("inlets").isJsonArray()) {
+        JsonArray inlets = unit.getAsJsonArray("inlets");
+        for (int j = 0; j < inlets.size(); j++) {
+          String ref = inlets.get(j).getAsString();
+          if (!validRefs.contains(ref)) {
+            report.addWarning("process[" + i + "].inlets[" + j + "] references unknown stream '"
+                + ref + "'");
+          }
+        }
+      }
+      if (unit.has("streams") && unit.get("streams").isJsonObject()) {
+        JsonObject streams = unit.getAsJsonObject("streams");
+        for (Map.Entry<String, JsonElement> e : streams.entrySet()) {
+          if (e.getValue().isJsonPrimitive() && e.getValue().getAsJsonPrimitive().isString()) {
+            String ref = e.getValue().getAsString();
+            if (isLikelyInputKey(e.getKey()) && !validRefs.contains(ref)) {
+              report.addWarning("process[" + i + "].streams." + e.getKey()
+                  + " references unknown stream '" + ref + "'");
+            }
+          }
+        }
+      }
+    }
+    return report;
+  }
+
+  private static void validateReferenceField(ValidationReport report, Set<String> validRefs,
+      JsonObject unit, int idx, String key) {
+    if (unit.has(key) && unit.get(key).isJsonPrimitive() && unit.get(key).getAsJsonPrimitive().isString()) {
+      String ref = unit.get(key).getAsString();
+      if (!validRefs.contains(ref)) {
+        report.addWarning("process[" + idx + "]." + key + " references unknown stream '" + ref
+            + "'");
+      }
+    }
+  }
+
+  private static boolean isLikelyInputKey(String key) {
+    String k = key.toLowerCase();
+    return k.contains("inlet") || "in".equals(k) || "feed".equals(k);
+  }
+
+  private static String getString(JsonObject obj, String key) {
+    if (!obj.has(key) || !obj.get(key).isJsonPrimitive()) {
+      return null;
+    }
+    return obj.get(key).getAsString();
+  }
+
+  public static final class ValidationReport {
+    private final List<String> errors = new ArrayList<String>();
+    private final List<String> warnings = new ArrayList<String>();
+
+    public boolean isValid() { return errors.isEmpty(); }
+    public List<String> getErrors() { return errors; }
+    public List<String> getWarnings() { return warnings; }
+    public int getErrorCount() { return errors.size(); }
+    public int getWarningCount() { return warnings.size(); }
+    public void addError(String error) { errors.add(error); }
+    public void addWarning(String warning) { warnings.add(warning); }
+  }
+}

--- a/src/main/java/neqsim/process/processmodel/ProcessSystem.java
+++ b/src/main/java/neqsim/process/processmodel/ProcessSystem.java
@@ -4954,6 +4954,11 @@ public class ProcessSystem extends SimulationBaseClass {
     return new JsonProcessBuilder().build(json);
   }
 
+  public static ProcessJsonValidator.ValidationReport validateJson(String json) {
+    return ProcessJsonValidator.validate(json);
+  }
+
+
   /**
    * Exports this ProcessSystem to the JSON schema consumed by {@link JsonProcessBuilder}.
    *

--- a/src/test/java/neqsim/process/processmodel/JsonProcessBuilderTest.java
+++ b/src/test/java/neqsim/process/processmodel/JsonProcessBuilderTest.java
@@ -638,4 +638,22 @@ class JsonProcessBuilderTest {
     assertNotNull(result.getProcessSystem().getUnit("Luva"));
     assertTrue(result.getProcessSystem().getUnit("Luva") instanceof UnisimCalculator);
   }
+
+  @Test
+  void testBuildWithExplicitConnectionsMetadata() {
+    String json = "{" + "\"fluid\": {" + "  \"model\": \"SRK\"," + "  \"temperature\": 298.15,"
+        + "  \"pressure\": 50.0," + "  \"components\": {\"methane\": 1.0}" + "},"
+        + "\"process\": [" + "  {\"type\": \"Stream\", \"name\": \"feed\"},"
+        + "  {\"type\": \"Separator\", \"name\": \"Sep\", \"inlet\": \"feed\"}" + "],"
+        + "\"connections\": ["
+        + "  {\"from\": \"feed\", \"to\": \"Sep\", \"sourcePort\": \"outlet\", \"targetPort\": \"inlet\", \"type\": \"MATERIAL\"}"
+        + "]" + "}";
+
+    SimulationResult result = new JsonProcessBuilder().build(json);
+    assertTrue(result.isSuccess(), "Build should succeed: " + result);
+    assertEquals(1, result.getProcessSystem().getConnections().size());
+    assertEquals(ProcessConnection.ConnectionType.MATERIAL,
+        result.getProcessSystem().getConnections().get(0).getType());
+  }
+
 }

--- a/src/test/java/neqsim/process/processmodel/JsonProcessBuilderTest.java
+++ b/src/test/java/neqsim/process/processmodel/JsonProcessBuilderTest.java
@@ -656,4 +656,27 @@ class JsonProcessBuilderTest {
         result.getProcessSystem().getConnections().get(0).getType());
   }
 
+
+  @Test
+  void testBuildWithMechanicalDesignPayload() {
+    String json = "{" + "\"fluid\": {" + "  \"model\": \"SRK\"," + "  \"temperature\": 298.15,"
+        + "  \"pressure\": 50.0,"
+        + "  \"components\": {\"methane\": 0.9, \"ethane\": 0.1}" + "},"
+        + "\"process\": ["
+        + "  {\"type\": \"Stream\", \"name\": \"feed\", \"properties\": {\"flowRate\": [10000.0, \"kg/hr\"]}},"
+        + "  {\"type\": \"Separator\", \"name\": \"Sep\", \"inlet\": \"feed\","
+        + "   \"properties\": {\"mechanicalDesign\": {\"gasLoadFactor\": 0.107, \"retentionTime\": 120.0}}}"
+        + "]" + "}";
+
+    SimulationResult result = new JsonProcessBuilder().build(json);
+    assertTrue(result.isSuccess(), "Build should succeed: " + result);
+    neqsim.process.equipment.separator.Separator sep =
+        (neqsim.process.equipment.separator.Separator) result.getProcessSystem().getUnit("Sep");
+    sep.initMechanicalDesign();
+    neqsim.process.mechanicaldesign.separator.SeparatorMechanicalDesign design =
+        (neqsim.process.mechanicaldesign.separator.SeparatorMechanicalDesign) sep.getMechanicalDesign();
+    assertEquals(0.107, design.getGasLoadFactor(), 1e-12);
+    assertEquals(120.0, design.getRetentionTime(), 1e-12);
+  }
+
 }

--- a/src/test/java/neqsim/process/processmodel/ProcessJsonValidatorTest.java
+++ b/src/test/java/neqsim/process/processmodel/ProcessJsonValidatorTest.java
@@ -1,0 +1,91 @@
+package neqsim.process.processmodel;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+class ProcessJsonValidatorTest {
+  @Test
+  void validJsonShouldPass() {
+    String json = "{\"process\":[{\"type\":\"Stream\",\"name\":\"feed\"},{\"type\":\"Separator\",\"name\":\"sep\",\"inlet\":\"feed\"}]}";
+    ProcessJsonValidator.ValidationReport report = ProcessJsonValidator.validate(json);
+    assertTrue(report.isValid());
+    assertTrue(report.getWarningCount() == 0);
+  }
+
+  @Test
+  void missingProcessShouldFail() {
+    ProcessJsonValidator.ValidationReport report = ProcessJsonValidator.validate("{}");
+    assertFalse(report.isValid());
+  }
+
+  @Test
+  void duplicateNamesShouldFail() {
+    String json = "{\"process\":[{\"type\":\"Stream\",\"name\":\"A\"},{\"type\":\"Stream\",\"name\":\"A\"}]}";
+    ProcessJsonValidator.ValidationReport report = ProcessJsonValidator.validate(json);
+    assertFalse(report.isValid());
+  }
+
+  @Test
+  void unknownStreamReferenceShouldWarnOnly() {
+    String json = "{\"process\":[{\"type\":\"Separator\",\"name\":\"sep\",\"inlet\":\"missing\"}]}";
+    ProcessJsonValidator.ValidationReport report = ProcessJsonValidator.validate(json);
+    assertTrue(report.isValid());
+    assertTrue(report.getWarningCount() > 0);
+  }
+
+  @Test
+  void processSystemValidateJsonMethodShouldWork() {
+    String json = "{\"process\":[{\"type\":\"Stream\",\"name\":\"feed\"}]}";
+    ProcessJsonValidator.ValidationReport report = ProcessSystem.validateJson(json);
+    assertTrue(report.isValid());
+  }
+
+  @Test
+  void nullJsonShouldFail() {
+    ProcessJsonValidator.ValidationReport report = ProcessJsonValidator.validate(null);
+    assertFalse(report.isValid());
+  }
+
+  @Test
+  void malformedJsonShouldFail() {
+    ProcessJsonValidator.ValidationReport report = ProcessJsonValidator.validate("{bad");
+    assertFalse(report.isValid());
+  }
+
+  @Test
+  void missingTypeShouldFail() {
+    String json = "{\"process\":[{\"name\":\"feed\"}]}";
+    ProcessJsonValidator.ValidationReport report = ProcessJsonValidator.validate(json);
+    assertFalse(report.isValid());
+  }
+
+  @Test
+  void missingNameShouldFail() {
+    String json = "{\"process\":[{\"type\":\"Stream\"}]}";
+    ProcessJsonValidator.ValidationReport report = ProcessJsonValidator.validate(json);
+    assertFalse(report.isValid());
+  }
+
+  @Test
+  void unknownReferenceInStreamsObjectShouldWarn() {
+    String json = "{\"process\":[{\"type\":\"Separator\",\"name\":\"sep\",\"streams\":{\"inlet\":\"ghost\"}}]}";
+    ProcessJsonValidator.ValidationReport report = ProcessJsonValidator.validate(json);
+    assertTrue(report.isValid());
+    assertTrue(report.getWarningCount() > 0);
+  }
+
+  @Test
+  void e300FluidDefinitionShouldValidate() {
+    String json = "{\"fluid\":{\"model\":\"PR_LK\",\"temperature\":310.15,\"pressure\":50.0,\"e300FilePath\":\"/tmp/fluid.e300\"},\"process\":[{\"type\":\"Stream\",\"name\":\"feed\"}]}";
+    ProcessJsonValidator.ValidationReport report = ProcessJsonValidator.validate(json);
+    assertTrue(report.isValid());
+  }
+
+  @Test
+  void namedFluidsWithFluidRefShouldValidate() {
+    String json = "{\"fluids\":{\"gas\":{\"model\":\"SRK\",\"temperature\":298.15,\"pressure\":50.0,\"components\":{\"methane\":1.0}}},\"process\":[{\"type\":\"Stream\",\"name\":\"gasFeed\",\"fluidRef\":\"gas\"}]}";
+    ProcessJsonValidator.ValidationReport report = ProcessJsonValidator.validate(json);
+    assertTrue(report.isValid());
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide a clearly documented, round-trippable JSON format for building and running `ProcessSystem` definitions and to make topology metadata first-class. 
- Add pre-flight validation to catch malformed or incomplete process JSON before attempting to build or run simulations. 
- Support optional explicit `connections` metadata so topology can be preserved for interchange, PFD export, and analysis.

### Description

- Adds a new documentation page `docs/process/json_process_models_and_systems.md` that documents the builder JSON schema, examples, validation workflow, E300 fluid support, and round-trip usage. 
- Implements `ProcessJsonValidator` with `ValidationReport` to perform structural checks (required `process` array, missing `type`/`name`, duplicate names) and emit warnings for unresolved stream references. 
- Adds `ProcessSystem.validateJson(String)` as a convenience wrapper around the validator. 
- Extends `JsonProcessBuilder` to optionally parse a root-level `connections` array and call `process.connect(...)` for each entry, including type parsing and warning/default handling for unknown values. 
- Adds unit tests in `ProcessJsonValidatorTest` and extends `JsonProcessBuilderTest` with `testBuildWithExplicitConnectionsMetadata` to verify the new behavior.

### Testing

- Ran the new and updated unit tests including `ProcessJsonValidatorTest` (valid/malformed JSON, missing fields, duplicate names, warnings for unknown references, E300 and named fluids) and `JsonProcessBuilderTest::testBuildWithExplicitConnectionsMetadata`. 
- Tests were executed via the project test suite and the new/updated tests passed. 
- Validator unit tests assert both error and warning counts to ensure validation rules behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6e38b36cc832d8b4b81e810347b58)