### PR TITLE
Add MDEA and EOS-CG-2021 reducing parameters; update EOS-CG model and docs

### DIFF
--- a/docs/thermo/fluid_creation_guide.md
+++ b/docs/thermo/fluid_creation_guide.md
@@ -241,9 +241,9 @@ double density = fluid.getPhase(0).getDensity_GERG2008();
 
 ### 5.2 EOS-CG
 
-Extension of GERG-2008 for CCS (Carbon Capture and Storage) applications. Includes combustion gas components.
+Extension of GERG-2008 for CCS (Carbon Capture and Storage) applications. Includes EOS-CG-2021 combustion-gas and amine impurity components.
 
-**Additional components:** SO2, NO, NO2, and others relevant to flue gas.
+**EOS-CG-2021 components:** CO2, H2O, N2, O2, Ar, CO, H2, CH4, H2S, SO2, MEA, DEA, HCl, Cl2, NH3, and MDEA.
 
 ```java
 import neqsim.thermo.system.SystemEOSCGEos;

--- a/docs/thermo/gerg2008_eoscg.md
+++ b/docs/thermo/gerg2008_eoscg.md
@@ -245,25 +245,16 @@ public class Gerg2008NH3Example {
 
 ## 5. EOS-CG
 
-**Full Name:** EOS-CG: A Helmholtz energy equation of state for combustion gases and CCS mixtures.
-**Authors:** J. Gernert and R. Span (Ruhr-Universität Bochum).
+**Full Name:** EOS-CG-2021: a Helmholtz energy equation of state for CCS mixtures.
+**Authors:** Tobias Neumann, Stefan Herrig, Ian Bell, Robin Beckmüller, Eric W. Lemmon, Monika Thol, and Roland Span.
 
 ### Application
-EOS-CG is an extension of the GERG framework designed for **Carbon Capture and Storage (CCS)** and **combustion gas** applications. It includes additional components found in flue gases and impurities relevant to CO2 transport.
+EOS-CG is an extension of the GERG framework designed for **Carbon Capture and Storage (CCS)** and **combustion gas** applications. It includes additional components found in CO2-rich transport streams and impurities relevant to CCS.
 
-### Supported Components (27)
-Includes all 21 components from GERG-2008, plus:
-*   Sulfur Dioxide (SO₂)
-*   Nitrogen Monoxide (NO)
-*   Nitrogen Dioxide (NO₂)
-*   Hydrogen Chloride (HCl)
-*   Chlorine (Cl₂)
-*   Carbonyl Sulfide (COS)
+### EOS-CG-2021 component coverage
+The EOS-CG-2021 publication defines a 16-component CCS model: CO₂, water, N₂, O₂, Ar, CO, H₂, CH₄, H₂S, SO₂, monoethanolamine (MEA), diethanolamine (DEA), HCl, Cl₂, NH₃, and methyl diethanolamine (MDEA). NeqSim keeps the GERG-style hydrocarbon slots for compatibility while refreshing the EOS-CG reducing-parameter table and adding MDEA as an EOS-CG component.
 
-Recent PRs refreshed the EOS-CG component tables with updated critical properties and binary
-interaction data, improving phase behavior for acid-gas heavy blends. The refresh aligns the
-library with the latest GERG-compatible datasets so CCS mixtures match reference densities and
-sound speed benchmarks more closely.
+Recent updates refreshed the EOS-CG component tables with the EOS-CG-2021 gas constant, MDEA pure-fluid parameters, and binary reducing parameters, improving consistency with the current CCS-mixture model.
 
 ### Usage in NeqSim
 
@@ -303,5 +294,7 @@ public class EosCgExample {
 1.  **GERG-2008:** Kunz, O., & Wagner, W. (2012). *The GERG-2008 Wide-Range Equation of State for Natural Gases and Other Mixtures: An Expansion of GERG-2004*. Journal of Chemical & Engineering Data, 57(11), 3032–3091.
 2.  **GERG-2008-H2:** Beckmüller, R., Thol, M., Sampson, I., Lemmon, E.W., & Span, R. (2022). *Extension of the equation of state for natural gases GERG-2008 with improved hydrogen parameters*. Fluid Phase Equilibria, 557, 113411.
 3.  **EOS-CG:** Gernert, J., & Span, R. (2016). *EOS-CG: A Helmholtz energy equation of state for combustion gases and CCS mixtures*. The Journal of Chemical Thermodynamics, 93, 274–293.
-4.  **GERG-2008-NH3:** Neumann, T., Thol, M., Lemmon, E.W., & Span, R. (2020). *Extension of the equation of state for natural gases (GERG-2008) with ammonia*. Molecular Physics, 118(21–22), e1769856.
-5.  **NH3 Pure-Fluid EOS:** Gao, K., Wu, J., & Lemmon, E.W. (2020). *A Helmholtz Energy Equation of State for Ammonia*. International Journal of Thermophysics, 41, 68.
+4.  **EOS-CG-2021:** Neumann, T., Herrig, S., Bell, I.H., Beckmüller, R., Lemmon, E.W., Thol, M., & Span, R. (2023). *EOS-CG-2021: A Mixture Model for the Calculation of Thermodynamic Properties of CCS Mixtures*. International Journal of Thermophysics, 44, 178.
+5.  **MDEA Pure-Fluid EOS:** Neumann, T., Baumhögger, E., Span, R., Vrabec, J., & Thol, M. (2022). *Thermodynamic Properties of Methyl Diethanolamine*. International Journal of Thermophysics, 43, 10.
+6.  **GERG-2008-NH3:** Neumann, T., Thol, M., Lemmon, E.W., & Span, R. (2020). *Extension of the equation of state for natural gases (GERG-2008) with ammonia*. Molecular Physics, 118(21–22), e1769856.
+7.  **NH3 Pure-Fluid EOS:** Gao, K., Wu, J., & Lemmon, E.W. (2020). *A Helmholtz Energy Equation of State for Ammonia*. International Journal of Thermophysics, 41, 68.

--- a/docs/thermo/thermodynamic_models.md
+++ b/docs/thermo/thermodynamic_models.md
@@ -291,7 +291,7 @@ ops.TPflash();
 ### 5.4 EOS-CG
 
 **Application:** Carbon Capture and Storage (CCS), combustion gases
-**Extension:** Includes SO2, NO, NO2, HCl, Cl2, COS in addition to GERG-2008 components
+**Extension:** EOS-CG-2021 CCS component set, including CO2, H2O, N2, O2, Ar, CO, H2, CH4, H2S, SO2, MEA, DEA, HCl, Cl2, NH3, and MDEA
 
 ```java
 import neqsim.thermo.system.SystemEOSCGEos;

--- a/src/main/java/neqsim/thermo/util/gerg/EOSCGModel.java
+++ b/src/main/java/neqsim/thermo/util/gerg/EOSCGModel.java
@@ -16,8 +16,8 @@ import neqsim.util.ExcludeFromJacocoGeneratedReport;
 public class EOSCGModel {
   // Variables containing the common parameters in the EOS-CG equations
   double REOSCG;
-  int NcEOSCG = 27;
-  int MaxFlds = 27;
+  int NcEOSCG = 28;
+  int MaxFlds = 28;
   int MaxMdl = 10;
   int MaxTrmM = 12;
   int MaxTrmP = 24;
@@ -899,8 +899,8 @@ public class EOSCGModel {
 
     double d0;
     // ThermodynamicConstantsInterface.R
-    REOSCG = 8.314472;
-    Rs = 8.31451;
+    REOSCG = 8.314462618;
+    Rs = 8.314462618;
     Rsr = Rs / REOSCG;
     o13 = 1.0 / 3.0;
 
@@ -2071,6 +2071,102 @@ public class EOSCGModel {
     th0i[27][5] = 1165.0 / 2.0;
     n0i[27][1] = 0.0 + 3.0 * Math.log(736.5) + (4.25 + 37.7) * Math.log(2.0);
     n0i[27][2] = 0.0 * 736.5 - (4.25 * 96.0 + 37.7 * 1165.0) / 2.0;
+
+    // MDEA (28) - Neumann et al. (2022), included in EOS-CG-2021.
+    MMiEOSCG[28] = 119.1622;
+    Dc[28] = 2.720;
+    Tc[28] = 741.0;
+    kpol[28] = 5;
+    kexp[28] = 5;
+    kgauss[28] = 5;
+    noik[28][1] = 0.05001068;
+    doik[28][1] = 4;
+    toik[28][1] = 1.0;
+    coik[28][1] = 0;
+    noik[28][2] = 1.629696;
+    doik[28][2] = 1;
+    toik[28][2] = 0.24;
+    coik[28][2] = 0;
+    noik[28][3] = -2.307822;
+    doik[28][3] = 1;
+    toik[28][3] = 0.98;
+    coik[28][3] = 0;
+    noik[28][4] = -0.6606441;
+    doik[28][4] = 2;
+    toik[28][4] = 1.18;
+    coik[28][4] = 0;
+    noik[28][5] = 0.2677026;
+    doik[28][5] = 3;
+    toik[28][5] = 0.38;
+    coik[28][5] = 0;
+    noik[28][6] = -1.858733;
+    doik[28][6] = 1;
+    toik[28][6] = 2.9;
+    coik[28][6] = 2;
+    noik[28][7] = -1.686275;
+    doik[28][7] = 3;
+    toik[28][7] = 3.03;
+    coik[28][7] = 2;
+    noik[28][8] = 0.3534702;
+    doik[28][8] = 2;
+    toik[28][8] = 0.67;
+    coik[28][8] = 1;
+    noik[28][9] = -2.007864;
+    doik[28][9] = 2;
+    toik[28][9] = 3.0;
+    coik[28][9] = 2;
+    noik[28][10] = -0.03826392;
+    doik[28][10] = 7;
+    toik[28][10] = 0.72;
+    coik[28][10] = 1;
+    k = 11;
+    noik[28][k] = 4.058964;
+    doik[28][k] = 1;
+    toik[28][k] = 1.63;
+    eta_pure[28][k] = 1.22;
+    beta_pure[28][k] = 1.02;
+    gamma_pure[28][k] = 1.4;
+    epsilon_pure[28][k] = 0.846;
+    k++;
+    noik[28][k] = -0.009984452;
+    doik[28][k] = 1;
+    toik[28][k] = 2.1;
+    eta_pure[28][k] = 19.6;
+    beta_pure[28][k] = 1000.0;
+    gamma_pure[28][k] = 1.08;
+    epsilon_pure[28][k] = 0.93;
+    k++;
+    noik[28][k] = -0.2906544;
+    doik[28][k] = 3;
+    toik[28][k] = 1.91;
+    eta_pure[28][k] = 1.5;
+    beta_pure[28][k] = 1.3;
+    gamma_pure[28][k] = 1.38;
+    epsilon_pure[28][k] = 0.98;
+    k++;
+    noik[28][k] = -0.6089361;
+    doik[28][k] = 2;
+    toik[28][k] = 1.92;
+    eta_pure[28][k] = 1.36;
+    beta_pure[28][k] = 1.3;
+    gamma_pure[28][k] = 1.19;
+    epsilon_pure[28][k] = 0.699;
+    k++;
+    noik[28][k] = -0.6822699;
+    doik[28][k] = 2;
+    toik[28][k] = 2.0;
+    eta_pure[28][k] = 1.6;
+    beta_pure[28][k] = 1.19;
+    gamma_pure[28][k] = 1.02;
+    epsilon_pure[28][k] = 0.698;
+    k++;
+    n0i[28][3] = 3.0;
+    n0i[28][4] = 31.94;
+    th0i[28][4] = 800.0 / 2.0;
+    n0i[28][5] = 29.98;
+    th0i[28][5] = 2382.0 / 2.0;
+    n0i[28][1] = 0.0 + 3.0 * Math.log(741.0) + (31.94 + 29.98) * Math.log(2.0);
+    n0i[28][2] = 0.0 * 741.0 - (31.94 * 800.0 + 29.98 * 2382.0) / 2.0;
     // Carbon dioxide
     coik[3][1] = 0;
     doik[3][1] = 1;
@@ -3904,6 +4000,8 @@ public class EOSCGModel {
     btij[20][21] = 1;
     gtij[20][21] = 1; // He-Ar
 
+    applyEOSCG2021ReducingParameters();
+
     for (int i = 1; i <= MaxFlds; ++i) {
       bvij[i][i] = 1;
       btij[i][i] = 1;
@@ -3962,6 +4060,143 @@ public class EOSCGModel {
     // n0i[i][2] = n0i[i][2] - T0;
     // n0i[i][1] = n0i[i][1] - log(d0);
     // }
+  }
+
+  private void applyEOSCG2021ReducingParameters() {
+    // EOS-CG-2021 Table 4: beta_T, gamma_T, beta_v, gamma_v, and F_ij.
+    setReducingParameter( 3, 18,  1.030538,  0.828472,  1.021392,  0.895156,  1.000000); // CO2 + H2O
+    setReducingParameter(27, 21,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // DEA + Ar
+    setReducingParameter( 2,  3,  1.005895,  1.107654,  0.977795,  1.047578,  1.000000); // N2 + CO2
+    setReducingParameter(25, 21,  1.000000,  1.074563,  1.000000,  1.001236,  0.000000); // HCl + Ar
+    setReducingParameter( 3, 16,  1.000000,  1.031986,  1.000000,  1.084460,  0.000000); // CO2 + O2
+    setReducingParameter(24, 21,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // Cl2 + Ar
+    setReducingParameter( 3, 21,  0.998705,  1.039675,  1.003766,  1.013833,  1.000000); // CO2 + Ar
+    setReducingParameter(21, 23,  1.146326,  0.998353,  0.756526,  1.041113,  1.000000); // Ar + NH3
+    setReducingParameter( 3, 17,  0.989782,  1.162130,  1.033802,  1.000162,  1.000000); // CO2 + CO
+    setReducingParameter(28, 21,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MDEA + Ar
+    setReducingParameter( 3, 15,  0.979000,  1.961000,  1.198000,  0.842000,  1.000000); // CO2 + H2
+    setReducingParameter(17, 15,  1.078000,  1.105000,  1.037000,  1.040000,  1.000000); // CO + H2
+    setReducingParameter( 1,  3,  1.022624,  0.975665,  0.999518,  1.002807,  1.000000); // CH4 + CO2
+    setReducingParameter( 1, 17,  0.987412,  0.987473,  0.997341,  1.006103,  0.000000); // CH4 + CO
+    setReducingParameter( 3, 19,  1.016035,  0.926019,  0.906631,  1.024086,  0.000000); // CO2 + H2S
+    setReducingParameter(17, 19,  1.025537,  1.022750,  0.795660,  1.101731,  0.000000); // CO + H2S
+    setReducingParameter( 3, 22,  1.020063,  1.007975,  0.889865,  1.005778,  0.000000); // CO2 + SO2
+    setReducingParameter(22, 17,  1.000000,  1.177903,  1.000000,  1.007241,  0.000000); // SO2 + CO
+    setReducingParameter(26,  3,  1.000000,  1.070000,  1.000000,  1.000000,  0.000000); // MEA + CO2
+    setReducingParameter(26, 17,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MEA + CO
+    setReducingParameter(27,  3,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // DEA + CO2
+    setReducingParameter(27, 17,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // DEA + CO
+    setReducingParameter(25,  3,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // HCl + CO2
+    setReducingParameter(25, 17,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // HCl + CO
+    setReducingParameter(24,  3,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // Cl2 + CO2
+    setReducingParameter(24, 17,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // Cl2 + CO
+    setReducingParameter(23,  3,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // NH3 + CO2
+    setReducingParameter(17, 23,  1.057512,  0.952705,  0.739937,  1.707000,  0.000000); // CO + NH3
+    setReducingParameter(28,  3,  1.081000,  1.386000,  1.000000,  1.000000,  0.000000); // MDEA + CO2
+    setReducingParameter(28, 17,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MDEA + CO
+    setReducingParameter( 2, 18,  1.048054,  0.805147,  0.926245,  0.733443,  1.000000); // N2 + H2O
+    setReducingParameter( 1, 15,  1.010000,  1.440000,  1.086000,  0.804000,  1.000000); // CH4 + H2
+    setReducingParameter(16, 18,  1.253060,  0.807842,  1.028197,  0.873460,  0.601700); // O2 + H2O
+    setReducingParameter(15, 19,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // H2 + H2S
+    setReducingParameter(18, 21,  0.679104,  0.921000,  0.940398,  1.050952,  0.000000); // H2O + Ar
+    setReducingParameter(22, 15,  1.000000,  1.940852,  1.000000,  1.035171,  0.000000); // SO2 + H2
+    setReducingParameter(17, 18,  0.956090,  0.823984,  0.940426,  0.766756,  0.989700); // CO + H2O
+    setReducingParameter(26, 15,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MEA + H2
+    setReducingParameter(15, 18,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // H2 + H2O
+    setReducingParameter(27, 15,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // DEA + H2
+    setReducingParameter( 1, 18,  1.263000,  0.748000,  1.176000,  1.038000,  1.000000); // CH4 + H2O
+    setReducingParameter(25, 15,  1.000000,  1.724556,  1.000000,  1.005948,  0.000000); // HCl + H2
+    setReducingParameter(19, 18,  0.960526,  0.924026,  0.945818,  1.189702,  1.000000); // H2S + H2O
+    setReducingParameter(24, 15,  1.000000,  1.914078,  1.000000,  1.035410,  0.000000); // Cl2 + H2
+    setReducingParameter(22, 18,  1.019562,  0.916311,  1.094032,  0.962547,  0.000000); // SO2 + H2O
+    setReducingParameter(15, 23,  0.988240,  1.126600,  1.010300,  0.729800,  1.000000); // H2 + NH3
+    setReducingParameter(26, 18,  1.004000,  0.957300,  1.007600,  1.089160,  1.000000); // MEA + H2O
+    setReducingParameter(28, 15,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MDEA + H2
+    setReducingParameter(27, 18,  0.993200,  0.973400,  1.006000,  1.123000,  1.000000); // DEA + H2O
+    setReducingParameter( 1, 19,  1.011090,  0.961156,  1.012599,  1.040161,  0.000000); // CH4 + H2S
+    setReducingParameter(25, 18,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // HCl + H2O
+    setReducingParameter(22,  1,  0.999432,  1.115714,  1.315534,  1.119543,  0.000000); // SO2 + CH4
+    setReducingParameter(24, 18,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // Cl2 + H2O
+    setReducingParameter(26,  1,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MEA + CH4
+    setReducingParameter(23, 18,  0.933585,  1.015826,  1.044759,  1.189754,  1.000000); // NH3 + H2O
+    setReducingParameter(27,  1,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // DEA + CH4
+    setReducingParameter(28, 18,  0.970000,  1.010000,  0.980000,  1.268700,  1.000000); // MDEA + H2O
+    setReducingParameter(25,  1,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // HCl + CH4
+    setReducingParameter( 2, 16,  0.997191,  0.995157,  0.999522,  0.997082,  0.000000); // N2 + O2
+    setReducingParameter(24,  1,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // Cl2 + CH4
+    setReducingParameter( 2, 21,  0.999442,  0.989311,  1.006697,  1.001549,  0.000000); // N2 + Ar
+    setReducingParameter( 1, 23,  1.022371,  0.940156,  1.006058,  1.069834,  0.000000); // CH4 + NH3
+    setReducingParameter( 2, 17,  1.002409,  0.994100,  1.000000,  1.001317,  0.000000); // N2 + CO
+    setReducingParameter(28,  1,  1.000000,  1.625000,  1.074000,  1.000000,  0.000000); // MDEA + CH4
+    setReducingParameter( 2, 15,  1.027000,  1.240000,  0.993000,  0.773000,  1.000000); // N2 + H2
+    setReducingParameter(22, 19,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // SO2 + H2S
+    setReducingParameter( 1,  2,  0.998099,  0.979273,  0.998721,  1.013950,  1.000000); // CH4 + N2
+    setReducingParameter(26, 19,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MEA + H2S
+    setReducingParameter( 2, 19,  1.004692,  0.960174,  0.910394,  1.256844,  0.000000); // N2 + H2S
+    setReducingParameter(27, 19,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // DEA + H2S
+    setReducingParameter(22,  2,  1.045874,  1.194659,  0.903625,  1.215581,  0.000000); // SO2 + N2
+    setReducingParameter(25, 19,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // HCl + H2S
+    setReducingParameter(26,  2,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MEA + N2
+    setReducingParameter(24, 19,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // Cl2 + H2S
+    setReducingParameter(27,  2,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // DEA + N2
+    setReducingParameter(23, 19,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // NH3 + H2S
+    setReducingParameter(25,  2,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // HCl + N2
+    setReducingParameter(28, 19,  1.000000,  1.059430,  1.000000,  1.140800,  0.000000); // MDEA + H2S
+    setReducingParameter(24,  2,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // Cl2 + N2
+    setReducingParameter(26, 22,  1.021293,  1.200045,  1.000000,  1.000000,  0.000000); // MEA + SO2
+    setReducingParameter( 2, 23,  1.057512,  0.952705,  0.739937,  1.447261,  0.000000); // N2 + NH3
+    setReducingParameter(27, 22,  1.021293,  1.200045,  1.000000,  1.000000,  0.000000); // DEA + SO2
+    setReducingParameter(28,  2,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MDEA + N2
+    setReducingParameter(22, 25,  1.002605,  1.048380,  1.000000,  1.000000,  0.000000); // SO2 + HCl
+    setReducingParameter(16, 21,  0.999039,  0.988822,  1.006502,  1.001341,  0.000000); // O2 + Ar
+    setReducingParameter(24, 22,  1.015678,  0.927820,  1.024354,  1.016621,  0.000000); // Cl2 + SO2
+    setReducingParameter(16, 17,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // O2 + CO
+    setReducingParameter(23, 22,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // NH3 + SO2
+    setReducingParameter(15, 16,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // H2 + O2
+    setReducingParameter(28, 22,  1.000000,  1.037046,  1.000000,  1.097897,  0.000000); // MDEA + SO2
+    setReducingParameter( 1, 16,  1.000000,  0.950000,  1.000000,  1.000000,  0.000000); // CH4 + O2
+    setReducingParameter(27, 26,  1.015703,  1.020484,  0.766762,  0.852448,  0.000000); // DEA + MEA
+    setReducingParameter(16, 19,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // O2 + H2S
+    setReducingParameter(26, 25,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MEA + HCl
+    setReducingParameter(22, 16,  0.927961,  1.035878,  1.219246,  1.660632,  0.000000); // SO2 + O2
+    setReducingParameter(26, 24,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MEA + Cl2
+    setReducingParameter(26, 16,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MEA + O2
+    setReducingParameter(23, 26,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // NH3 + MEA
+    setReducingParameter(27, 16,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // DEA + O2
+    setReducingParameter(28, 26,  1.000000,  0.805000,  1.000000,  1.000000,  0.000000); // MDEA + MEA
+    setReducingParameter(25, 16,  1.000000,  1.069638,  1.000000,  1.001592,  0.000000); // HCl + O2
+    setReducingParameter(27, 25,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // DEA + HCl
+    setReducingParameter(24, 16,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // Cl2 + O2
+    setReducingParameter(27, 24,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // DEA + Cl2
+    setReducingParameter(23, 16,  1.000000,  1.118566,  1.000000,  1.000002,  0.000000); // NH3 + O2
+    setReducingParameter(23, 27,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // NH3 + DEA
+    setReducingParameter(28, 16,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MDEA + O2
+    setReducingParameter(28, 27,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MDEA + DEA
+    setReducingParameter(17, 21,  1.000000,  0.954216,  1.000000,  1.159721,  0.000000); // CO + Ar
+    setReducingParameter(24, 25,  1.007373,  0.968865,  0.928100,  0.917288,  0.000000); // Cl2 + HCl
+    setReducingParameter(15, 21,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // H2 + Ar
+    setReducingParameter(23, 25,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // NH3 + HCl
+    setReducingParameter( 1, 21,  0.990954,  0.989843,  1.034630,  1.014679,  0.000000); // CH4 + Ar
+    setReducingParameter(28, 25,  1.000000,  1.086325,  1.000000,  1.173873,  0.000000); // MDEA + HCl
+    setReducingParameter(19, 21,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // H2S + Ar
+    setReducingParameter(23, 24,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // NH3 + Cl2
+    setReducingParameter(22, 21,  1.000000,  1.141020,  1.000000,  1.021291,  0.000000); // SO2 + Ar
+    setReducingParameter(28, 24,  1.000000,  1.041648,  1.000000,  1.096224,  0.000000); // MDEA + Cl2
+    setReducingParameter(26, 21,  1.000000,  1.000000,  1.000000,  1.000000,  0.000000); // MEA + Ar
+    setReducingParameter(28, 23,  1.000000,  1.045755,  1.000000,  1.207629,  0.000000); // MDEA + NH3
+  }
+
+
+  private void setReducingParameter(int i, int j, double betaT, double gammaT, double betaV,
+      double gammaV, double departureWeight) {
+    int row = Math.min(i, j);
+    int col = Math.max(i, j);
+    btij[row][col] = betaT;
+    gtij[row][col] = gammaT;
+    bvij[row][col] = betaV;
+    gvij[row][col] = gammaV;
+    fij[row][col] = departureWeight;
+    fij[col][row] = departureWeight;
   }
 
   /**

--- a/src/main/java/neqsim/thermo/util/gerg/NeqSimEOSCG.java
+++ b/src/main/java/neqsim/thermo/util/gerg/NeqSimEOSCG.java
@@ -25,8 +25,8 @@ public class NeqSimEOSCG {
   private static volatile EOSCG cachedModel = null;
   private static final Object CACHE_LOCK = new Object();
 
-  double[] normalizedComposition = new double[27 + 1];
-  double[] notNormalizedComposition = new double[27 + 1];
+  double[] normalizedComposition = new double[28 + 1];
+  double[] notNormalizedComposition = new double[28 + 1];
   PhaseInterface phase = null;
   EOSCG eosCG;
 
@@ -261,6 +261,11 @@ public class NeqSimEOSCG {
           break;
         case "DEA":
           notNormalizedComposition[27] = phase.getComponent(i).getx();
+          break;
+        case "MDEA":
+        case "methyldiethanolamine":
+        case "methyl diethanolamine":
+          notNormalizedComposition[28] = phase.getComponent(i).getx();
           break;
         default:
           double molarMass = phase.getComponent(i).getMolarMass();

--- a/src/test/java/neqsim/thermo/util/gerg/EOSCG2021MDEATest.java
+++ b/src/test/java/neqsim/thermo/util/gerg/EOSCG2021MDEATest.java
@@ -1,0 +1,35 @@
+package neqsim.thermo.util.gerg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.netlib.util.doubleW;
+
+/** Tests EOS-CG-2021 methyl diethanolamine pure-fluid data. */
+class EOSCG2021MDEATest {
+  @Test
+  void mdeaMolarMassUsesEosCg2021ComponentSlot() {
+    EOSCG eos = new EOSCG();
+    eos.setup();
+    double[] composition = new double[29];
+    composition[28] = 1.0;
+    doubleW molarMass = new doubleW(0.0);
+
+    eos.molarMass(composition, molarMass);
+
+    assertEquals(119.1622, molarMass.val, 1.0e-8);
+  }
+
+  @Test
+  void mdeaPressureMatchesPublishedImplementationValue() {
+    EOSCG eos = new EOSCG();
+    eos.setup();
+    double[] composition = new double[29];
+    composition[28] = 1.0;
+    doubleW pressure = new doubleW(0.0);
+    doubleW z = new doubleW(0.0);
+
+    eos.pressure(300.0, 8.8, composition, pressure, z);
+
+    assertEquals(34241.92443746, pressure.val, 1.0e-4);
+  }
+}


### PR DESCRIPTION
### Motivation
- Add support for methyl diethanolamine (MDEA) and bring EOS-CG implementation in line with the EOS-CG-2021 CCS/amine component set and reducing-parameter table.
- Refresh EOS-CG pure-fluid and reducing parameters for improved phase behavior and consistency with the EOS-CG-2021 publication.

### Description
- Extend the EOS-CG implementation by increasing the component slot count to 28, include MDEA pure-fluid parameters in `SetupEOSCG()`, and add the EOS-CG-2021 reducing-parameter table via `applyEOSCG2021ReducingParameters()` and helper `setReducingParameter()` in `EOSCGModel.java`.
- Adjust numeric gas constant precision (`REOSCG`/`Rs`) and wire up the new reducing parameters to the `bvij`, `gvij`, `btij`, `gtij`, and `fij` tables during setup.
- Update the NeqSim wrapper `NeqSimEOSCG` to allocate composition arrays for 28 components and map component names `MDEA` / `methyldiethanolamine` / `methyl diethanolamine` into the new EOS-CG component slot.
- Update documentation files (`thermo/*`) to describe EOS-CG-2021 component coverage, authorship, and references, and to mention MDEA support and the refreshed tables.

### Testing
- Added unit tests `EOSCG2021MDEATest` with two JUnit cases that verify MDEA molar mass and a reference pressure value, run with `mvn -Dtest=neqsim.thermo.util.gerg.EOSCG2021MDEATest test` and passing.
- Ran the project unit test suite with `mvn test` and the test suite completed successfully (no failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2043864e38832dbaade5f9f1900c5b)