### PR TITLE
Add compressor thermal model and selectable catalog

### DIFF
--- a/docs/compressor_thermal_model.md
+++ b/docs/compressor_thermal_model.md
@@ -1,0 +1,57 @@
+# Compressor thermal model and catalog
+
+`CompressorThermalModel` is a reduced-order thermal resistance/capacitance network for estimating temperatures at locations that are not represented by the process-gas outlet temperature. Standard locations include the inlet shaft, impeller, casing, dry-gas seal, radial bearing and thrust bearing. Fluid boundaries include suction gas, discharge gas, seal gas, lube oil and ambient air.
+
+The model is intended for screening, sensitivity analysis, transient studies and fitting to measured temperatures. It is not a substitute for an OEM finite-element or conjugate heat-transfer model.
+
+## Governing equation
+
+For every non-boundary node (i), NeqSim solves
+
+\[
+C_i \frac{dT_i}{dt} = Q_i + \sum_j G_{ij}(T_j-T_i)
+\]
+
+where (C_i) is the lumped heat capacity in J/K, (Q_i) is local heat generation in W, and (G_{ij}) is an effective thermal conductance in W/K. The steady-state solver sets the storage term to zero. The transient solver uses implicit Euler, which remains stable for time steps larger than the shortest thermal time constant, although accuracy still depends on time-step selection.
+
+Bearing-loss heat can be supplied by `CompressorMechanicalLosses`. A configurable fraction of gas-compression power can be deposited at the impeller node. That fraction is a fitted parameter, not a universal physical constant.
+
+## Catalog workflow
+
+```java
+CompressorCatalog catalog = CompressorCatalog.createDefaultCatalog();
+compressor.initMechanicalLosses(120.0);
+compressor.applyCatalogEntry(catalog, "generic-centrifugal-single-stage");
+compressor.run();
+
+double shaftTemperature = compressor.getThermalModel()
+    .getTemperature(CompressorThermalModel.INLET_SHAFT, "C");
+Map<String, Double> temperatures = compressor.getThermalModel().getTemperatureProfile("C");
+```
+
+`CompressorCatalog` is JSON-backed. It can hold generic templates or private machine definitions and records the machine-specific inputs required for calibration. Applying an entry makes an independent copy, so changing one compressor does not alter the catalog or another compressor.
+
+The built-in catalog values are deliberately generic. Replace at least:
+
+- thermal conductances, using OEM geometry, material data, heat-transfer analysis or fitted measurements;
+- node heat capacities, using the participating metal mass and heat capacity;
+- bearing losses, using vendor curves or an oil-side heat balance;
+- seal-gas and lube-oil temperatures and flows;
+- the fraction of compression power transferred to rotor metal.
+
+## Condensate evaporation and sulfur-deposition screening
+
+A shaft can be warmer than the suction gas because it is connected conductively to the impeller/rotor and receives heat from bearings, seals and the compressed gas. If entrained condensate wets this location, compare the calculated metal temperature with a NeqSim flash of a representative condensate at local pressure. A higher equilibrium vapor fraction at the metal temperature indicates an evaporation-driving force. Evaporation can concentrate dissolved elemental sulfur and other low-volatility material at the surface.
+
+This comparison does not by itself predict a deposition rate. A defensible sulfur assessment also needs entrained liquid rate and droplet size, condensate composition, sulfur solubility versus pressure and temperature, residence time, mass transfer, surface temperature distribution, and chemical sulfur production. The thermal model exposes the metal-temperature input needed by that assessment.
+
+## Literature basis and limitations
+
+- [API Standard 617](https://www.api.org/~/media/files/publications/whats%20new/617_e8%20pa.pdf) defines the scope and minimum requirements for process centrifugal compressors. It is used here to identify relevant compressor and auxiliary-system boundaries; it does not provide the generic conductances in the templates.
+- [API Standard 692](https://www.api.org/-/media/files/publications/2025-catalog/06_refining_2025.pdf) defines dry-gas sealing-system scope. It does not provide a universal seal-face or shaft-temperature correlation.
+- Lo et al., [Parameter Estimation of the Thermal Network Model of a Machine Tool Spindle](https://doi.org/10.3390/s18020656), demonstrates a calibrated resistance/capacitance network with shaft, housing and bearing temperatures for both steady and transient prediction.
+- Lin et al., [Experimental and Numerical Analysis of the Impeller Backside Cavity in a Centrifugal Compressor](https://doi.org/10.3390/en15020420), shows measured radial temperature gradients and operating-speed effects in a compressor impeller backside cavity. This supports retaining distinct impeller, casing and shaft nodes instead of assigning the discharge-gas temperature to all metal.
+- Stahl et al., [Heat Transfer Effects on a Rotor-Centrifugal Compressor](https://gpps.global/wp-content/uploads/2021/02/GPPS-TC-2019_paper_54.pdf), compares heat-transfer models with experimental compressor data and illustrates that heat transfer affects rotor-compressor behavior.
+- Ding et al., [Theoretical analysis and experiment on gas film temperature in a spiral groove dry gas seal](https://doi.org/10.1016/j.ijheatmasstransfer.2015.12.024), reports measured seal temperature distributions and shows why a seal location should not simply be assigned the supply-gas temperature.
+
+The network is linear in conductance and uses one temperature per lumped node. Radiation, temperature-dependent properties, rotationally dependent convection, contact resistance, detailed oil-film behavior, spatial gradients within a node and droplet evaporation kinetics are not calculated unless the user represents them through fitted links, additional nodes or an external model.

--- a/examples/notebooks/compressor_thermal_catalog.ipynb
+++ b/examples/notebooks/compressor_thermal_catalog.ipynb
@@ -1,0 +1,194 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compressor thermal network and condensate-evaporation screening\n",
+    "\n",
+    "This example selects a generic compressor from the NeqSim compressor catalog, calculates local screening temperatures, and checks whether an entrained hydrocarbon-condensate droplet would partly evaporate at the inlet-shaft temperature. Such evaporation can concentrate dissolved elemental sulfur at the metal surface.\n",
+    "\n",
+    "> The built-in thermal conductances and heat capacities are illustrative. Replace them with OEM geometry, vendor loss data, oil/seal measurements, or fitted plant data before making integrity or operating decisions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import sys\n",
+    "\n",
+    "root = Path.cwd().resolve()\n",
+    "while root != root.parent and not (root / 'devtools' / 'neqsim_dev_setup.py').exists():\n",
+    "    root = root.parent\n",
+    "sys.path.insert(0, str(root / 'devtools'))\n",
+    "from neqsim_dev_setup import neqsim_init, neqsim_classes\n",
+    "ns = neqsim_classes(neqsim_init(recompile=True))\n",
+    "\n",
+    "CompressorCatalog = ns.JClass('neqsim.process.equipment.compressor.CompressorCatalog')\n",
+    "CompressorThermalModel = ns.JClass('neqsim.process.equipment.compressor.CompressorThermalModel')\n",
+    "ThermodynamicOperations = ns.JClass('neqsim.thermodynamicoperations.ThermodynamicOperations')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Gas and compressor\n",
+    "\n",
+    "The process gas is deliberately rich enough to represent a recompressor service where a small liquid carry-over is credible. The process simulation supplies suction and discharge temperatures to the thermal network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gas = ns.SystemSrkEos(273.15 + 25.0, 50.0)\n",
+    "for component, amount in [('methane', 0.88), ('ethane', 0.06), ('propane', 0.03),\n",
+    "                          ('n-butane', 0.015), ('n-pentane', 0.010), ('n-hexane', 0.005)]:\n",
+    "    gas.addComponent(component, amount)\n",
+    "gas.setMixingRule('classic')\n",
+    "inlet = ns.Stream('recompressor inlet', gas)\n",
+    "inlet.setFlowRate(1.0, 'MSm3/day')\n",
+    "inlet.run()\n",
+    "\n",
+    "compressor = ns.Compressor('recompressor', inlet)\n",
+    "compressor.setOutletPressure(100.0, 'bara')\n",
+    "compressor.setIsentropicEfficiency(0.78)\n",
+    "losses = compressor.initMechanicalLosses(120.0)\n",
+    "losses.setSealGasSupplyTemperature(40.0)\n",
+    "losses.setLubeOilInletTemp(40.0)\n",
+    "losses.setLubeOilOutletTemp(55.0)\n",
+    "\n",
+    "catalog = CompressorCatalog.createDefaultCatalog()\n",
+    "compressor.applyCatalogEntry(catalog, 'generic-centrifugal-single-stage')\n",
+    "compressor.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = compressor.getThermalModel()\n",
+    "profile_c = {str(e.getKey()): float(e.getValue()) for e in model.getTemperatureProfile('C').entrySet()}\n",
+    "for location, temperature in profile_c.items():\n",
+    "    print(f'{location:20s} {temperature:8.2f} degC')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Entrained-condensate evaporation at the inlet shaft\n",
+    "\n",
+    "A separate representative condensate is flashed at suction pressure and at the calculated shaft temperature. The resulting equilibrium gas fraction is a screening indicator for local evaporation. It is not a droplet heat/mass-transfer model, and elemental-sulfur solubility must be evaluated separately."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "condensate = ns.SystemSrkEos(273.15 + 25.0, inlet.getPressure('bara'))\n",
+    "for component, amount in [('n-butane', 0.20), ('n-pentane', 0.30),\n",
+    "                          ('n-hexane', 0.30), ('n-heptane', 0.20)]:\n",
+    "    condensate.addComponent(component, amount)\n",
+    "condensate.setMixingRule('classic')\n",
+    "ops = ThermodynamicOperations(condensate)\n",
+    "\n",
+    "def equilibrium_gas_fraction(temperature_c):\n",
+    "    condensate.setTemperature(temperature_c, 'C')\n",
+    "    condensate.setPressure(inlet.getPressure('bara'), 'bara')\n",
+    "    ops.TPflash()\n",
+    "    return float(condensate.getPhaseFraction('gas', 'mole')) if condensate.hasPhaseType('gas') else 0.0\n",
+    "\n",
+    "shaft_c = profile_c['inlet-shaft']\n",
+    "gas_fraction_inlet = equilibrium_gas_fraction(inlet.getTemperature('C'))\n",
+    "gas_fraction_shaft = equilibrium_gas_fraction(shaft_c)\n",
+    "print(f'Condensate equilibrium gas fraction at inlet: {gas_fraction_inlet:.4f}')\n",
+    "print(f'Condensate equilibrium gas fraction at shaft: {gas_fraction_shaft:.4f}')\n",
+    "print(f'Additional equilibrium evaporation potential: {gas_fraction_shaft-gas_fraction_inlet:.4f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Machine-specific calibration inputs\n",
+    "\n",
+    "The catalog keeps the inputs that should be replaced for a real machine next to the model, so a UI or engineering workflow can expose them directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "entry = catalog.get('generic-centrifugal-single-stage')\n",
+    "for e in entry.getRequiredParameters().entrySet():\n",
+    "    print(f'- {e.getKey()}: {e.getValue()}')\n",
+    "\n",
+    "# Example calibration: change one effective conductance, then resolve.\n",
+    "for link in model.getLinks():\n",
+    "    connected = {str(link.getFromNodeId()), str(link.getToNodeId())}\n",
+    "    if connected == {'inlet-shaft', 'impeller'}:\n",
+    "        link.setConductanceWPerK(500.0)\n",
+    "compressor.solveThermalModel()\n",
+    "print('Calibrated inlet-shaft temperature:',\n",
+    "      model.getTemperature(CompressorThermalModel.INLET_SHAFT, 'C'), 'degC')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Transient temperature\n",
+    "\n",
+    "For start-up, shutdown, hot restart, or changing seal/oil conditions, disable automatic steady-state solving and advance the implicit transient model with the process time step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.setAutoSolve(False)\n",
+    "shaft_history = []\n",
+    "for minute in range(61):\n",
+    "    shaft_history.append((minute, model.getTemperature('inlet-shaft', 'C')))\n",
+    "    compressor.solveThermalModelTransient(60.0)\n",
+    "\n",
+    "try:\n",
+    "    import matplotlib.pyplot as plt\n",
+    "    plt.plot([x[0] for x in shaft_history], [x[1] for x in shaft_history])\n",
+    "    plt.xlabel('Time [min]')\n",
+    "    plt.ylabel('Inlet-shaft temperature [degC]')\n",
+    "    plt.grid(True)\n",
+    "except ImportError:\n",
+    "    print(shaft_history[:5], '...', shaft_history[-1])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -198,6 +198,9 @@ public class Compressor extends TwoPortEquipment
   /** Mechanical losses model for seal gas and bearing calculations. */
   private CompressorMechanicalLosses mechanicalLosses = null;
 
+  /** Optional lumped thermal network for local metal, bearing, seal and casing temperatures. */
+  private CompressorThermalModel thermalModel = null;
+
   private String pressureUnit = "bara";
   private String polytropicMethod = "schultz";
 
@@ -296,6 +299,57 @@ public class Compressor extends TwoPortEquipment
    */
   public void setMechanicalLosses(CompressorMechanicalLosses mechanicalLosses) {
     this.mechanicalLosses = mechanicalLosses;
+  }
+
+  /**
+   * Get the optional compressor thermal network.
+   *
+   * @return thermal model, or null when not configured
+   */
+  public CompressorThermalModel getThermalModel() {
+    return thermalModel;
+  }
+
+  /**
+   * Attach a compressor thermal network.
+   *
+   * @param thermalModel thermal model, or null to remove it
+   */
+  public void setThermalModel(CompressorThermalModel thermalModel) {
+    this.thermalModel = thermalModel;
+  }
+
+  /**
+   * Apply a named definition from a compressor catalog.
+   *
+   * @param catalog compressor catalog
+   * @param entryId catalog entry identifier
+   */
+  public void applyCatalogEntry(CompressorCatalog catalog, String entryId) {
+    if (catalog == null) {
+      throw new IllegalArgumentException("compressor catalog must not be null");
+    }
+    catalog.apply(entryId, this);
+  }
+
+  /** Solve the attached thermal network at steady state. */
+  public void solveThermalModel() {
+    if (thermalModel == null) {
+      throw new IllegalStateException("no thermal model is attached to compressor '" + getName() + "'");
+    }
+    thermalModel.solveSteadyState(this);
+  }
+
+  /**
+   * Advance the attached thermal network by one implicit transient step.
+   *
+   * @param timeStepSeconds time step in seconds
+   */
+  public void solveThermalModelTransient(double timeStepSeconds) {
+    if (thermalModel == null) {
+      throw new IllegalStateException("no thermal model is attached to compressor '" + getName() + "'");
+    }
+    thermalModel.solveTransient(this, timeStepSeconds);
   }
 
   /**
@@ -476,6 +530,12 @@ public class Compressor extends TwoPortEquipment
           ProcessEquipmentInterface.createStateEntry(out.getTemperature(temperatureUnit), temperatureUnit));
     }
     state.put("power", ProcessEquipmentInterface.createStateEntry(getPower("kW"), "kW"));
+    if (thermalModel != null) {
+      for (Map.Entry<String, Double> temperature : thermalModel.getTemperatureProfile(temperatureUnit).entrySet()) {
+        state.put("thermal_" + temperature.getKey(),
+            ProcessEquipmentInterface.createStateEntry(temperature.getValue(), temperatureUnit));
+      }
+    }
     return state;
   }
 
@@ -633,6 +693,9 @@ public class Compressor extends TwoPortEquipment
 
   private void finishRun(UUID id) {
     updateRecalculationState();
+    if (thermalModel != null && thermalModel.isAutoSolve()) {
+      thermalModel.solveSteadyState(this);
+    }
     if (outStream != null) {
       outStream.setCalculationIdentifier(id);
     }

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorCatalog.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorCatalog.java
@@ -1,0 +1,234 @@
+package neqsim.process.equipment.compressor;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import com.google.gson.GsonBuilder;
+import neqsim.process.equipment.compressor.CompressorThermalLink.Mechanism;
+import neqsim.process.equipment.compressor.CompressorThermalNode.NodeType;
+
+/**
+ * JSON-backed catalog of selectable compressor definitions.
+ *
+ * <p>
+ * Built-in entries are generic screening templates, not vendor performance guarantees. Users can
+ * add private OEM definitions, serialize the catalog and select an entry by stable identifier.
+ * </p>
+ */
+public class CompressorCatalog implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private String name = "compressor catalog";
+  private final Map<String, CompressorCatalogEntry> entries =
+      new LinkedHashMap<String, CompressorCatalogEntry>();
+
+  /** Create an empty catalog. */
+  public CompressorCatalog() {}
+
+  /** @param name catalog name */
+  public CompressorCatalog(String name) {
+    setName(name);
+  }
+
+  /** @return catalog name */
+  public String getName() {
+    return name;
+  }
+
+  /** @param name non-empty catalog name */
+  public void setName(String name) {
+    if (name == null || name.trim().isEmpty()) {
+      throw new IllegalArgumentException("catalog name must not be empty");
+    }
+    this.name = name;
+  }
+
+  /**
+   * Add or replace a catalog entry.
+   *
+   * @param entry entry to add or replace
+   * @return this catalog
+   */
+  public CompressorCatalog add(CompressorCatalogEntry entry) {
+    if (entry == null) {
+      throw new IllegalArgumentException("catalog entry must not be null");
+    }
+    entries.put(entry.getId(), entry);
+    return this;
+  }
+
+  /**
+   * Get a catalog entry.
+   *
+   * @param id entry id
+   * @return matching entry or null
+   */
+  public CompressorCatalogEntry get(String id) {
+    return entries.get(id);
+  }
+
+  /** @return entry ids in insertion order */
+  public List<String> getIds() {
+    return new ArrayList<String>(entries.keySet());
+  }
+
+  /** @return immutable view of entries */
+  public Map<String, CompressorCatalogEntry> getEntries() {
+    return Collections.unmodifiableMap(entries);
+  }
+
+  /**
+   * Apply a catalog entry to a compressor.
+   *
+   * @param id catalog entry id
+   * @param compressor target compressor
+   */
+  public void apply(String id, Compressor compressor) {
+    CompressorCatalogEntry entry = entries.get(id);
+    if (entry == null) {
+      throw new IllegalArgumentException("no compressor catalog entry named '" + id
+          + "'; available: " + getIds());
+    }
+    entry.applyTo(compressor);
+  }
+
+  /** @return round-trippable pretty-printed JSON */
+  public String toJson() {
+    return new GsonBuilder().serializeSpecialFloatingPointValues().setPrettyPrinting().create()
+        .toJson(this);
+  }
+
+  /**
+   * Deserialize a compressor catalog.
+   *
+   * @param json serialized catalog
+   * @return deserialized catalog
+   */
+  public static CompressorCatalog fromJson(String json) {
+    if (json == null || json.trim().isEmpty()) {
+      throw new IllegalArgumentException("compressor catalog JSON must not be empty");
+    }
+    return new GsonBuilder().serializeSpecialFloatingPointValues().create().fromJson(json,
+        CompressorCatalog.class);
+  }
+
+  /**
+   * Save this catalog as JSON.
+   *
+   * @param path output file path
+   * @throws IOException if writing fails
+   */
+  public void save(String path) throws IOException {
+    Files.write(Paths.get(path), toJson().getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Load a catalog from JSON.
+   *
+   * @param path catalog file path
+   * @return loaded catalog
+   * @throws IOException if reading fails
+   */
+  public static CompressorCatalog load(String path) throws IOException {
+    byte[] bytes = Files.readAllBytes(Paths.get(path));
+    return fromJson(new String(bytes, StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Create generic centrifugal-compressor templates with explicitly documented calibration inputs.
+   *
+   * @return catalog containing single-stage and multistage dry-gas-seal templates
+   */
+  public static CompressorCatalog createDefaultCatalog() {
+    CompressorCatalog catalog = new CompressorCatalog("NeqSim generic compressor templates");
+    catalog.add(createGenericEntry("generic-centrifugal-single-stage", 1, 3.0e5, 120.0));
+    catalog.add(createGenericEntry("generic-centrifugal-multistage", 5, 8.0e5, 220.0));
+    return catalog;
+  }
+
+  private static CompressorCatalogEntry createGenericEntry(String id, int stages,
+      double rotorHeatCapacity, double rotorGasConductance) {
+    CompressorThermalModel model = new CompressorThermalModel(id + " thermal network");
+    model.addNode(boundary(CompressorThermalModel.SUCTION_GAS, 293.15));
+    model.addNode(boundary(CompressorThermalModel.DISCHARGE_GAS, 373.15));
+    model.addNode(boundary(CompressorThermalModel.SEAL_GAS, 313.15));
+    model.addNode(boundary(CompressorThermalModel.LUBE_OIL, 320.65));
+    model.addNode(boundary(CompressorThermalModel.AMBIENT, 298.15));
+    model.addNode(node(CompressorThermalModel.INLET_SHAFT, NodeType.SHAFT, 313.15,
+        0.35 * rotorHeatCapacity));
+    model.addNode(node(CompressorThermalModel.IMPELLER, NodeType.IMPELLER, 333.15,
+        0.65 * rotorHeatCapacity));
+    model.addNode(node(CompressorThermalModel.CASING, NodeType.CASING, 323.15,
+        1.2 * rotorHeatCapacity));
+    model.addNode(node(CompressorThermalModel.DRY_GAS_SEAL, NodeType.SEAL, 313.15,
+        5.0e4));
+    model.addNode(node(CompressorThermalModel.RADIAL_BEARING, NodeType.RADIAL_BEARING,
+        323.15, 8.0e4));
+    model.addNode(node(CompressorThermalModel.THRUST_BEARING, NodeType.THRUST_BEARING,
+        323.15, 8.0e4));
+
+    link(model, CompressorThermalModel.SUCTION_GAS, CompressorThermalModel.INLET_SHAFT,
+        80.0, Mechanism.CONVECTION);
+    link(model, CompressorThermalModel.DISCHARGE_GAS, CompressorThermalModel.IMPELLER,
+        rotorGasConductance, Mechanism.CONVECTION);
+    link(model, CompressorThermalModel.INLET_SHAFT, CompressorThermalModel.IMPELLER,
+        350.0, Mechanism.CONDUCTION);
+    link(model, CompressorThermalModel.IMPELLER, CompressorThermalModel.CASING, 90.0,
+        Mechanism.EFFECTIVE);
+    link(model, CompressorThermalModel.CASING, CompressorThermalModel.AMBIENT, 45.0,
+        Mechanism.CONVECTION);
+    link(model, CompressorThermalModel.INLET_SHAFT, CompressorThermalModel.DRY_GAS_SEAL,
+        140.0, Mechanism.CONDUCTION);
+    link(model, CompressorThermalModel.DRY_GAS_SEAL, CompressorThermalModel.SEAL_GAS,
+        70.0, Mechanism.CONVECTION);
+    link(model, CompressorThermalModel.INLET_SHAFT, CompressorThermalModel.RADIAL_BEARING,
+        120.0, Mechanism.CONDUCTION);
+    link(model, CompressorThermalModel.INLET_SHAFT, CompressorThermalModel.THRUST_BEARING,
+        100.0, Mechanism.CONDUCTION);
+    link(model, CompressorThermalModel.RADIAL_BEARING, CompressorThermalModel.LUBE_OIL,
+        350.0, Mechanism.CONVECTION);
+    link(model, CompressorThermalModel.THRUST_BEARING, CompressorThermalModel.LUBE_OIL,
+        300.0, Mechanism.CONVECTION);
+    model.setCompressionHeatFractionToImpeller(0.002);
+
+    CompressorCatalogEntry entry = new CompressorCatalogEntry(id, "NeqSim", "generic template");
+    entry.setNumberOfStages(stages);
+    entry.setThermalModel(model);
+    entry.requireParameter("thermal conductances W/K",
+        "Fit each link from OEM geometry, heat-transfer analysis or measured temperatures")
+        .requireParameter("node heat capacities J/K",
+            "Calculate from participating metal mass and temperature-dependent heat capacity")
+        .requireParameter("bearing losses kW",
+            "Use vendor loss curves, oil heat balance or a validated bearing model")
+        .requireParameter("seal and lube-oil temperatures C",
+            "Use measured supply and return temperatures at the operating condition")
+        .requireParameter("compression heat fraction",
+            "Fit the rotor heat pickup; the generic value is only a screening assumption")
+        .addReference("API 617", "Axial and Centrifugal Compressors and Expander-compressors")
+        .addReference("API 692", "Dry Gas Sealing Systems for Compressors and Expanders")
+        .addReference("model equation",
+            "Lumped thermal capacitance energy balance solved as a resistance network");
+    return entry;
+  }
+
+  private static CompressorThermalNode boundary(String id, double temperatureK) {
+    return new CompressorThermalNode(id, NodeType.FLUID_BOUNDARY, temperatureK, 0.0, true);
+  }
+
+  private static CompressorThermalNode node(String id, NodeType type, double temperatureK,
+      double heatCapacityJPerK) {
+    return new CompressorThermalNode(id, type, temperatureK, heatCapacityJPerK, false);
+  }
+
+  private static void link(CompressorThermalModel model, String from, String to,
+      double conductance, Mechanism mechanism) {
+    model.addLink(new CompressorThermalLink(from, to, conductance, mechanism));
+  }
+}

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorCatalogEntry.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorCatalogEntry.java
@@ -1,0 +1,160 @@
+package neqsim.process.equipment.compressor;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** A selectable compressor definition containing metadata and a thermal-model template. */
+public class CompressorCatalogEntry implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  private String id;
+  private String manufacturer;
+  private String model;
+  private String compressorType = "centrifugal";
+  private int numberOfStages = 1;
+  private CompressorThermalModel thermalModel;
+  private final Map<String, String> requiredParameters = new LinkedHashMap<String, String>();
+  private final Map<String, String> references = new LinkedHashMap<String, String>();
+
+  /** No-argument constructor for JSON deserialization. */
+  public CompressorCatalogEntry() {}
+
+  /**
+   * Create a catalog entry.
+   *
+   * @param id unique catalog identifier
+   * @param manufacturer manufacturer or generic-template owner
+   * @param model model designation
+   */
+  public CompressorCatalogEntry(String id, String manufacturer, String model) {
+    setId(id);
+    setManufacturer(manufacturer);
+    setModel(model);
+  }
+
+  /** @return unique catalog identifier */
+  public String getId() {
+    return id;
+  }
+
+  /** @param id unique non-empty catalog identifier */
+  public void setId(String id) {
+    if (id == null || id.trim().isEmpty()) {
+      throw new IllegalArgumentException("catalog entry id must not be empty");
+    }
+    this.id = id;
+  }
+
+  /** @return manufacturer */
+  public String getManufacturer() {
+    return manufacturer;
+  }
+
+  /** @param manufacturer manufacturer or template owner */
+  public void setManufacturer(String manufacturer) {
+    if (manufacturer == null || manufacturer.trim().isEmpty()) {
+      throw new IllegalArgumentException("manufacturer must not be empty");
+    }
+    this.manufacturer = manufacturer;
+  }
+
+  /** @return model designation */
+  public String getModel() {
+    return model;
+  }
+
+  /** @param model model designation */
+  public void setModel(String model) {
+    if (model == null || model.trim().isEmpty()) {
+      throw new IllegalArgumentException("model must not be empty");
+    }
+    this.model = model;
+  }
+
+  /** @return compressor type */
+  public String getCompressorType() {
+    return compressorType;
+  }
+
+  /** @param compressorType compressor type */
+  public void setCompressorType(String compressorType) {
+    if (compressorType == null || compressorType.trim().isEmpty()) {
+      throw new IllegalArgumentException("compressor type must not be empty");
+    }
+    this.compressorType = compressorType;
+  }
+
+  /** @return stage count */
+  public int getNumberOfStages() {
+    return numberOfStages;
+  }
+
+  /** @param numberOfStages positive stage count */
+  public void setNumberOfStages(int numberOfStages) {
+    if (numberOfStages <= 0) {
+      throw new IllegalArgumentException("number of stages must be positive");
+    }
+    this.numberOfStages = numberOfStages;
+  }
+
+  /** @return thermal-model template */
+  public CompressorThermalModel getThermalModel() {
+    return thermalModel;
+  }
+
+  /** @param thermalModel thermal-model template */
+  public void setThermalModel(CompressorThermalModel thermalModel) {
+    this.thermalModel = thermalModel;
+  }
+
+  /**
+   * Document a machine-specific input needed to replace a screening assumption.
+   *
+   * @param parameterName parameter name
+   * @param description engineering description and expected unit
+   * @return this entry
+   */
+  public CompressorCatalogEntry requireParameter(String parameterName, String description) {
+    if (parameterName == null || parameterName.trim().isEmpty()) {
+      throw new IllegalArgumentException("parameter name must not be empty");
+    }
+    requiredParameters.put(parameterName, description);
+    return this;
+  }
+
+  /** @return immutable machine-specific parameter descriptions */
+  public Map<String, String> getRequiredParameters() {
+    return Collections.unmodifiableMap(requiredParameters);
+  }
+
+  /**
+   * Add a traceable source for the entry.
+   *
+   * @param name short source name
+   * @param reference citation or URL
+   * @return this entry
+   */
+  public CompressorCatalogEntry addReference(String name, String reference) {
+    references.put(name, reference);
+    return this;
+  }
+
+  /** @return immutable source map */
+  public Map<String, String> getReferences() {
+    return Collections.unmodifiableMap(references);
+  }
+
+  /**
+   * Apply independent model instances to a compressor.
+   *
+   * @param compressor target compressor
+   */
+  public void applyTo(Compressor compressor) {
+    if (compressor == null) {
+      throw new IllegalArgumentException("compressor must not be null");
+    }
+    compressor.setThermalModel(thermalModel == null ? null : thermalModel.copy());
+  }
+}

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorThermalLink.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorThermalLink.java
@@ -1,0 +1,106 @@
+package neqsim.process.equipment.compressor;
+
+import java.io.Serializable;
+
+/** A linear thermal conductance between two compressor temperature nodes. */
+public class CompressorThermalLink implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Heat-transfer mechanism represented by a link. */
+  public enum Mechanism {
+    /** Solid conduction. */
+    CONDUCTION,
+    /** Fluid-to-surface or surface-to-fluid convection. */
+    CONVECTION,
+    /** Combined or empirically fitted heat transfer. */
+    EFFECTIVE
+  }
+
+  private String fromNodeId;
+  private String toNodeId;
+  private double conductanceWPerK;
+  private Mechanism mechanism = Mechanism.EFFECTIVE;
+
+  /** No-argument constructor for JSON deserialization. */
+  public CompressorThermalLink() {}
+
+  /**
+   * Create a thermal link.
+   *
+   * @param fromNodeId first node
+   * @param toNodeId second node
+   * @param conductanceWPerK effective conductance in W/K
+   */
+  public CompressorThermalLink(String fromNodeId, String toNodeId, double conductanceWPerK) {
+    this(fromNodeId, toNodeId, conductanceWPerK, Mechanism.EFFECTIVE);
+  }
+
+  /**
+   * Create a thermal link.
+   *
+   * @param fromNodeId first node
+   * @param toNodeId second node
+   * @param conductanceWPerK effective conductance in W/K
+   * @param mechanism heat-transfer mechanism
+   */
+  public CompressorThermalLink(String fromNodeId, String toNodeId, double conductanceWPerK,
+      Mechanism mechanism) {
+    setFromNodeId(fromNodeId);
+    setToNodeId(toNodeId);
+    setConductanceWPerK(conductanceWPerK);
+    setMechanism(mechanism);
+  }
+
+  /** @return first node identifier */
+  public String getFromNodeId() {
+    return fromNodeId;
+  }
+
+  /** @param fromNodeId first node identifier */
+  public void setFromNodeId(String fromNodeId) {
+    this.fromNodeId = requireNodeId(fromNodeId);
+  }
+
+  /** @return second node identifier */
+  public String getToNodeId() {
+    return toNodeId;
+  }
+
+  /** @param toNodeId second node identifier */
+  public void setToNodeId(String toNodeId) {
+    this.toNodeId = requireNodeId(toNodeId);
+  }
+
+  /** @return effective conductance in W/K */
+  public double getConductanceWPerK() {
+    return conductanceWPerK;
+  }
+
+  /** @param conductanceWPerK effective conductance in W/K */
+  public void setConductanceWPerK(double conductanceWPerK) {
+    if (!Double.isFinite(conductanceWPerK) || conductanceWPerK <= 0.0) {
+      throw new IllegalArgumentException("thermal conductance must be finite and positive");
+    }
+    this.conductanceWPerK = conductanceWPerK;
+  }
+
+  /** @return heat-transfer mechanism */
+  public Mechanism getMechanism() {
+    return mechanism;
+  }
+
+  /** @param mechanism heat-transfer mechanism */
+  public void setMechanism(Mechanism mechanism) {
+    if (mechanism == null) {
+      throw new IllegalArgumentException("thermal link mechanism must not be null");
+    }
+    this.mechanism = mechanism;
+  }
+
+  private static String requireNodeId(String id) {
+    if (id == null || id.trim().isEmpty()) {
+      throw new IllegalArgumentException("thermal link node id must not be empty");
+    }
+    return id;
+  }
+}

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorThermalModel.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorThermalModel.java
@@ -1,0 +1,435 @@
+package neqsim.process.equipment.compressor;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import com.google.gson.GsonBuilder;
+
+/**
+ * Lumped-parameter thermal network for a compressor.
+ *
+ * <p>
+ * Each non-boundary node obeys {@code C dT/dt = Q + sum(G * (Tneighbour - T))}. The
+ * steady-state and implicit-Euler transient solvers use the same network. Conductances and heat
+ * capacities are deliberately explicit calibration parameters: local metal temperatures depend on
+ * machine geometry, material, oil flow, seal flow and operating history and cannot be inferred from
+ * the process-gas outlet temperature alone.
+ * </p>
+ *
+ * <p>
+ * API 617 and API 692 define the relevant compressor, bearing and dry-gas-seal system scope. They
+ * do not provide a universal rotor thermal network. Template values supplied by
+ * {@link CompressorCatalog} are therefore screening values and should be replaced with OEM data or
+ * fitted plant measurements before integrity decisions are made.
+ * </p>
+ */
+public class CompressorThermalModel implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Standard node identifier for suction process gas. */
+  public static final String SUCTION_GAS = "suction-gas";
+  /** Standard node identifier for discharge process gas. */
+  public static final String DISCHARGE_GAS = "discharge-gas";
+  /** Standard node identifier for the inlet-end shaft. */
+  public static final String INLET_SHAFT = "inlet-shaft";
+  /** Standard node identifier for the impeller or rotor active section. */
+  public static final String IMPELLER = "impeller";
+  /** Standard node identifier for the casing. */
+  public static final String CASING = "casing";
+  /** Standard node identifier for the dry-gas seal. */
+  public static final String DRY_GAS_SEAL = "dry-gas-seal";
+  /** Standard node identifier for seal-gas supply. */
+  public static final String SEAL_GAS = "seal-gas";
+  /** Standard node identifier for radial bearings. */
+  public static final String RADIAL_BEARING = "radial-bearing";
+  /** Standard node identifier for the thrust bearing. */
+  public static final String THRUST_BEARING = "thrust-bearing";
+  /** Standard node identifier for lube oil. */
+  public static final String LUBE_OIL = "lube-oil";
+  /** Standard node identifier for ambient air. */
+  public static final String AMBIENT = "ambient";
+
+  private String name = "compressor thermal model";
+  private final Map<String, CompressorThermalNode> nodes =
+      new LinkedHashMap<String, CompressorThermalNode>();
+  private final List<CompressorThermalLink> links = new ArrayList<CompressorThermalLink>();
+  private boolean autoSolve = true;
+  private boolean useMechanicalLossHeatSources = true;
+  private double compressionHeatFractionToImpeller = 0.0;
+
+  /** Create an empty thermal network. */
+  public CompressorThermalModel() {}
+
+  /** @param name descriptive model name */
+  public CompressorThermalModel(String name) {
+    setName(name);
+  }
+
+  /** @return model name */
+  public String getName() {
+    return name;
+  }
+
+  /** @param name non-empty model name */
+  public void setName(String name) {
+    if (name == null || name.trim().isEmpty()) {
+      throw new IllegalArgumentException("thermal model name must not be empty");
+    }
+    this.name = name;
+  }
+
+  /**
+   * Add or replace a node.
+   *
+   * @param node thermal node
+   * @return this model
+   */
+  public CompressorThermalModel addNode(CompressorThermalNode node) {
+    if (node == null) {
+      throw new IllegalArgumentException("thermal node must not be null");
+    }
+    nodes.put(node.getId(), node);
+    return this;
+  }
+
+  /**
+   * Add a thermal link. Both nodes must already be present.
+   *
+   * @param link thermal link
+   * @return this model
+   */
+  public CompressorThermalModel addLink(CompressorThermalLink link) {
+    if (link == null) {
+      throw new IllegalArgumentException("thermal link must not be null");
+    }
+    if (!nodes.containsKey(link.getFromNodeId()) || !nodes.containsKey(link.getToNodeId())) {
+      throw new IllegalArgumentException("both thermal link nodes must be added before the link");
+    }
+    if (link.getFromNodeId().equals(link.getToNodeId())) {
+      throw new IllegalArgumentException("thermal link must connect two different nodes");
+    }
+    links.add(link);
+    return this;
+  }
+
+  /**
+   * Get a node by identifier.
+   *
+   * @param id node identifier
+   * @return node, or null if absent
+   */
+  public CompressorThermalNode getNode(String id) {
+    return nodes.get(id);
+  }
+
+  /** @return immutable view of nodes in insertion order */
+  public Map<String, CompressorThermalNode> getNodes() {
+    return Collections.unmodifiableMap(nodes);
+  }
+
+  /** @return immutable view of thermal links */
+  public List<CompressorThermalLink> getLinks() {
+    return Collections.unmodifiableList(links);
+  }
+
+  /** @return true when an attached compressor solves this model after a process run */
+  public boolean isAutoSolve() {
+    return autoSolve;
+  }
+
+  /** @param autoSolve solve automatically after an attached compressor process run */
+  public void setAutoSolve(boolean autoSolve) {
+    this.autoSolve = autoSolve;
+  }
+
+  /** @return true when bearing correlations contribute heat to matching nodes */
+  public boolean isUseMechanicalLossHeatSources() {
+    return useMechanicalLossHeatSources;
+  }
+
+  /** @param useMechanicalLossHeatSources include configured bearing losses as node heat */
+  public void setUseMechanicalLossHeatSources(boolean useMechanicalLossHeatSources) {
+    this.useMechanicalLossHeatSources = useMechanicalLossHeatSources;
+  }
+
+  /** @return fraction of gas-compression power deposited as impeller heat */
+  public double getCompressionHeatFractionToImpeller() {
+    return compressionHeatFractionToImpeller;
+  }
+
+  /**
+   * Set the fitted fraction of gas-compression power deposited in the impeller thermal node.
+   *
+   * @param fraction fraction from 0 to 1
+   */
+  public void setCompressionHeatFractionToImpeller(double fraction) {
+    if (!Double.isFinite(fraction) || fraction < 0.0 || fraction > 1.0) {
+      throw new IllegalArgumentException("compression heat fraction must be between zero and one");
+    }
+    compressionHeatFractionToImpeller = fraction;
+  }
+
+  /**
+   * Update standard fluid-boundary nodes from a completed compressor calculation.
+   *
+   * @param compressor compressor supplying process and utility temperatures
+   */
+  public void updateBoundaryTemperatures(Compressor compressor) {
+    if (compressor == null) {
+      throw new IllegalArgumentException("compressor must not be null");
+    }
+    if (compressor.getInletStream() != null) {
+      setBoundaryIfPresent(SUCTION_GAS, compressor.getInletStream().getTemperature("K"));
+    }
+    if (compressor.getOutletStream() != null
+        && compressor.getOutletStream().getThermoSystem() != null) {
+      setBoundaryIfPresent(DISCHARGE_GAS, compressor.getOutletStream().getTemperature("K"));
+    }
+    CompressorMechanicalLosses losses = compressor.getMechanicalLosses();
+    if (losses != null) {
+      setBoundaryIfPresent(SEAL_GAS, losses.getSealGasSupplyTemperature() + 273.15);
+      double oilTemperatureK =
+          0.5 * (losses.getLubeOilInletTemp() + losses.getLubeOilOutletTemp()) + 273.15;
+      setBoundaryIfPresent(LUBE_OIL, oilTemperatureK);
+    }
+  }
+
+  private void setBoundaryIfPresent(String id, double temperatureK) {
+    CompressorThermalNode node = nodes.get(id);
+    if (node != null && node.isFixedTemperature()) {
+      node.setTemperatureK(temperatureK);
+    }
+  }
+
+  /** Solve the steady-state thermal network without compressor-generated heat sources. */
+  public void solveSteadyState() {
+    solve(false, 0.0, null);
+  }
+
+  /**
+   * Update boundaries and solve the steady-state thermal network.
+   *
+   * @param compressor attached compressor
+   */
+  public void solveSteadyState(Compressor compressor) {
+    updateBoundaryTemperatures(compressor);
+    solve(false, 0.0, compressor);
+  }
+
+  /**
+   * Advance the thermal network with an unconditionally stable implicit-Euler step.
+   *
+   * @param timeStepSeconds positive time step in seconds
+   */
+  public void solveTransient(double timeStepSeconds) {
+    solve(true, timeStepSeconds, null);
+  }
+
+  /**
+   * Update boundaries and advance the thermal network with an implicit-Euler step.
+   *
+   * @param compressor attached compressor
+   * @param timeStepSeconds positive time step in seconds
+   */
+  public void solveTransient(Compressor compressor, double timeStepSeconds) {
+    updateBoundaryTemperatures(compressor);
+    solve(true, timeStepSeconds, compressor);
+  }
+
+  private void solve(boolean transientStep, double timeStepSeconds, Compressor compressor) {
+    if (transientStep && (!Double.isFinite(timeStepSeconds) || timeStepSeconds <= 0.0)) {
+      throw new IllegalArgumentException("thermal time step must be finite and positive");
+    }
+    List<CompressorThermalNode> unknowns = new ArrayList<CompressorThermalNode>();
+    Map<String, Integer> unknownIndex = new LinkedHashMap<String, Integer>();
+    boolean hasBoundary = false;
+    for (CompressorThermalNode node : nodes.values()) {
+      if (node.isFixedTemperature()) {
+        hasBoundary = true;
+      } else {
+        if (transientStep && node.getHeatCapacityJPerK() <= 0.0) {
+          throw new IllegalStateException("transient node '" + node.getId()
+              + "' must have positive heat capacity");
+        }
+        unknownIndex.put(node.getId(), unknowns.size());
+        unknowns.add(node);
+      }
+    }
+    if (!hasBoundary && !unknowns.isEmpty()) {
+      throw new IllegalStateException("thermal network needs at least one fixed-temperature node");
+    }
+    if (unknowns.isEmpty()) {
+      return;
+    }
+
+    double[][] coefficients = new double[unknowns.size()][unknowns.size()];
+    double[] rightHandSide = new double[unknowns.size()];
+    for (int i = 0; i < unknowns.size(); i++) {
+      CompressorThermalNode node = unknowns.get(i);
+      rightHandSide[i] = node.getHeatGenerationW() + getCompressorHeatSource(node.getId(), compressor);
+      if (transientStep) {
+        double storage = node.getHeatCapacityJPerK() / timeStepSeconds;
+        coefficients[i][i] += storage;
+        rightHandSide[i] += storage * node.getTemperatureK();
+      }
+    }
+
+    for (CompressorThermalLink link : links) {
+      addLinkToEquations(link.getFromNodeId(), link.getToNodeId(), link.getConductanceWPerK(),
+          unknownIndex, coefficients, rightHandSide);
+      addLinkToEquations(link.getToNodeId(), link.getFromNodeId(), link.getConductanceWPerK(),
+          unknownIndex, coefficients, rightHandSide);
+    }
+    double[] solution = solveLinearSystem(coefficients, rightHandSide);
+    for (int i = 0; i < unknowns.size(); i++) {
+      unknowns.get(i).setTemperatureK(solution[i]);
+    }
+  }
+
+  private void addLinkToEquations(String nodeId, String neighbourId, double conductance,
+      Map<String, Integer> unknownIndex, double[][] coefficients, double[] rightHandSide) {
+    Integer row = unknownIndex.get(nodeId);
+    if (row == null) {
+      return;
+    }
+    coefficients[row][row] += conductance;
+    Integer column = unknownIndex.get(neighbourId);
+    if (column == null) {
+      CompressorThermalNode boundary = nodes.get(neighbourId);
+      rightHandSide[row] += conductance * boundary.getTemperatureK();
+    } else {
+      coefficients[row][column] -= conductance;
+    }
+  }
+
+  private double getCompressorHeatSource(String nodeId, Compressor compressor) {
+    if (compressor == null) {
+      return 0.0;
+    }
+    if (IMPELLER.equals(nodeId)) {
+      return compressionHeatFractionToImpeller * Math.abs(compressor.getPower());
+    }
+    if (!useMechanicalLossHeatSources || compressor.getMechanicalLosses() == null) {
+      return 0.0;
+    }
+    compressor.updateMechanicalLosses();
+    if (RADIAL_BEARING.equals(nodeId)) {
+      return 1000.0 * compressor.getMechanicalLosses().calculateRadialBearingLoss();
+    }
+    if (THRUST_BEARING.equals(nodeId)) {
+      return 1000.0 * compressor.getMechanicalLosses().calculateThrustBearingLoss();
+    }
+    return 0.0;
+  }
+
+  private static double[] solveLinearSystem(double[][] matrix, double[] vector) {
+    int size = vector.length;
+    for (int pivot = 0; pivot < size; pivot++) {
+      int bestRow = pivot;
+      for (int row = pivot + 1; row < size; row++) {
+        if (Math.abs(matrix[row][pivot]) > Math.abs(matrix[bestRow][pivot])) {
+          bestRow = row;
+        }
+      }
+      if (Math.abs(matrix[bestRow][pivot]) < 1.0e-12) {
+        throw new IllegalStateException("thermal network is singular or contains an isolated node");
+      }
+      double[] rowSwap = matrix[pivot];
+      matrix[pivot] = matrix[bestRow];
+      matrix[bestRow] = rowSwap;
+      double valueSwap = vector[pivot];
+      vector[pivot] = vector[bestRow];
+      vector[bestRow] = valueSwap;
+
+      for (int row = pivot + 1; row < size; row++) {
+        double factor = matrix[row][pivot] / matrix[pivot][pivot];
+        for (int column = pivot; column < size; column++) {
+          matrix[row][column] -= factor * matrix[pivot][column];
+        }
+        vector[row] -= factor * vector[pivot];
+      }
+    }
+    double[] result = new double[size];
+    for (int row = size - 1; row >= 0; row--) {
+      double sum = vector[row];
+      for (int column = row + 1; column < size; column++) {
+        sum -= matrix[row][column] * result[column];
+      }
+      result[row] = sum / matrix[row][row];
+      if (!Double.isFinite(result[row]) || result[row] <= 0.0) {
+        throw new IllegalStateException("thermal solution produced a non-physical temperature");
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Get one calculated temperature.
+   *
+   * @param nodeId node identifier
+   * @param unit K, C, degC, F or degF
+   * @return temperature in requested unit
+   */
+  public double getTemperature(String nodeId, String unit) {
+    CompressorThermalNode node = nodes.get(nodeId);
+    if (node == null) {
+      throw new IllegalArgumentException("no thermal node named '" + nodeId + "'");
+    }
+    return convertTemperature(node.getTemperatureK(), unit);
+  }
+
+  /**
+   * Get all calculated temperatures in insertion order.
+   *
+   * @param unit K, C, degC, F or degF
+   * @return node-to-temperature map
+   */
+  public Map<String, Double> getTemperatureProfile(String unit) {
+    Map<String, Double> profile = new LinkedHashMap<String, Double>();
+    for (CompressorThermalNode node : nodes.values()) {
+      profile.put(node.getId(), convertTemperature(node.getTemperatureK(), unit));
+    }
+    return profile;
+  }
+
+  private static double convertTemperature(double temperatureK, String unit) {
+    if ("K".equalsIgnoreCase(unit)) {
+      return temperatureK;
+    }
+    if ("C".equalsIgnoreCase(unit) || "degC".equalsIgnoreCase(unit)) {
+      return temperatureK - 273.15;
+    }
+    if ("F".equalsIgnoreCase(unit) || "degF".equalsIgnoreCase(unit)) {
+      return (temperatureK - 273.15) * 9.0 / 5.0 + 32.0;
+    }
+    throw new IllegalArgumentException("unsupported temperature unit '" + unit + "'");
+  }
+
+  /** @return pretty-printed, round-trippable JSON */
+  public String toJson() {
+    return new GsonBuilder().serializeSpecialFloatingPointValues().setPrettyPrinting().create()
+        .toJson(this);
+  }
+
+  /**
+   * Deserialize a thermal model.
+   *
+   * @param json serialized model
+   * @return deserialized thermal model
+   */
+  public static CompressorThermalModel fromJson(String json) {
+    if (json == null || json.trim().isEmpty()) {
+      throw new IllegalArgumentException("thermal model JSON must not be empty");
+    }
+    return new GsonBuilder().serializeSpecialFloatingPointValues().create().fromJson(json,
+        CompressorThermalModel.class);
+  }
+
+  /** @return independent deep copy */
+  public CompressorThermalModel copy() {
+    return fromJson(toJson());
+  }
+}

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorThermalNode.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorThermalNode.java
@@ -1,0 +1,142 @@
+package neqsim.process.equipment.compressor;
+
+import java.io.Serializable;
+
+/** A lumped temperature node in a {@link CompressorThermalModel}. */
+public class CompressorThermalNode implements Serializable {
+  private static final long serialVersionUID = 1000L;
+
+  /** Physical role of a thermal node. */
+  public enum NodeType {
+    /** Process or utility fluid whose temperature is imposed by an external calculation. */
+    FLUID_BOUNDARY,
+    /** Compressor shaft or rotor metal. */
+    SHAFT,
+    /** Compressor impeller metal. */
+    IMPELLER,
+    /** Compressor casing metal. */
+    CASING,
+    /** Radial bearing or bearing housing. */
+    RADIAL_BEARING,
+    /** Thrust bearing or bearing housing. */
+    THRUST_BEARING,
+    /** Dry-gas or oil seal hardware. */
+    SEAL,
+    /** User-defined compressor location. */
+    OTHER
+  }
+
+  private String id;
+  private String description;
+  private NodeType type;
+  private double temperatureK;
+  private double heatCapacityJPerK;
+  private double heatGenerationW;
+  private boolean fixedTemperature;
+
+  /** No-argument constructor for JSON deserialization. */
+  public CompressorThermalNode() {}
+
+  /**
+   * Create a thermal node.
+   *
+   * @param id unique node identifier
+   * @param type physical node type
+   * @param temperatureK initial temperature in K
+   * @param heatCapacityJPerK lumped heat capacity in J/K
+   * @param fixedTemperature whether the node is an imposed boundary temperature
+   */
+  public CompressorThermalNode(String id, NodeType type, double temperatureK,
+      double heatCapacityJPerK, boolean fixedTemperature) {
+    setId(id);
+    setType(type);
+    setTemperatureK(temperatureK);
+    setHeatCapacityJPerK(heatCapacityJPerK);
+    this.fixedTemperature = fixedTemperature;
+  }
+
+  /** @return node identifier */
+  public String getId() {
+    return id;
+  }
+
+  /** @param id unique non-empty node identifier */
+  public void setId(String id) {
+    if (id == null || id.trim().isEmpty()) {
+      throw new IllegalArgumentException("thermal node id must not be empty");
+    }
+    this.id = id;
+  }
+
+  /** @return node description */
+  public String getDescription() {
+    return description;
+  }
+
+  /** @param description node description */
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  /** @return physical node type */
+  public NodeType getType() {
+    return type;
+  }
+
+  /** @param type physical node type */
+  public void setType(NodeType type) {
+    if (type == null) {
+      throw new IllegalArgumentException("thermal node type must not be null");
+    }
+    this.type = type;
+  }
+
+  /** @return temperature in K */
+  public double getTemperatureK() {
+    return temperatureK;
+  }
+
+  /** @param temperatureK temperature in K */
+  public void setTemperatureK(double temperatureK) {
+    if (!Double.isFinite(temperatureK) || temperatureK <= 0.0) {
+      throw new IllegalArgumentException("temperature must be finite and above 0 K");
+    }
+    this.temperatureK = temperatureK;
+  }
+
+  /** @return lumped heat capacity in J/K */
+  public double getHeatCapacityJPerK() {
+    return heatCapacityJPerK;
+  }
+
+  /** @param heatCapacityJPerK lumped heat capacity in J/K, zero only for fixed nodes */
+  public void setHeatCapacityJPerK(double heatCapacityJPerK) {
+    if (!Double.isFinite(heatCapacityJPerK) || heatCapacityJPerK < 0.0) {
+      throw new IllegalArgumentException("heat capacity must be finite and non-negative");
+    }
+    this.heatCapacityJPerK = heatCapacityJPerK;
+  }
+
+  /** @return user-specified heat generation in W */
+  public double getHeatGenerationW() {
+    return heatGenerationW;
+  }
+
+  /** @param heatGenerationW user-specified heat generation in W */
+  public void setHeatGenerationW(double heatGenerationW) {
+    if (!Double.isFinite(heatGenerationW)) {
+      throw new IllegalArgumentException("heat generation must be finite");
+    }
+    this.heatGenerationW = heatGenerationW;
+  }
+
+  /** @return true if the temperature is externally imposed */
+  public boolean isFixedTemperature() {
+    return fixedTemperature;
+  }
+
+  /** @param fixedTemperature whether the temperature is externally imposed */
+  public void setFixedTemperature(boolean fixedTemperature) {
+    this.fixedTemperature = fixedTemperature;
+  }
+}

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorCatalogTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorCatalogTest.java
@@ -1,0 +1,75 @@
+package neqsim.process.equipment.compressor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.stream.Stream;
+import neqsim.thermo.system.SystemSrkEos;
+
+/** Tests for compressor catalog selection and process-equipment integration. */
+public class CompressorCatalogTest {
+
+  @Test
+  void defaultCatalogDocumentsCalibrationInputs() {
+    CompressorCatalog catalog = CompressorCatalog.createDefaultCatalog();
+
+    assertEquals(2, catalog.getIds().size());
+    CompressorCatalogEntry entry = catalog.get("generic-centrifugal-single-stage");
+    assertNotNull(entry);
+    assertTrue(entry.getRequiredParameters().containsKey("thermal conductances W/K"));
+    assertTrue(entry.getReferences().containsKey("API 617"));
+    assertNotNull(entry.getThermalModel().getNode(CompressorThermalModel.INLET_SHAFT));
+  }
+
+  @Test
+  void catalogJsonRoundTripsAndApplicationCopiesTemplate() {
+    CompressorCatalog original = CompressorCatalog.createDefaultCatalog();
+    CompressorCatalog restored = CompressorCatalog.fromJson(original.toJson());
+    Compressor first = new Compressor("first");
+    Compressor second = new Compressor("second");
+
+    restored.apply("generic-centrifugal-multistage", first);
+    restored.apply("generic-centrifugal-multistage", second);
+
+    assertNotSame(first.getThermalModel(), second.getThermalModel());
+    first.getThermalModel().getNode(CompressorThermalModel.AMBIENT).setTemperatureK(315.0);
+    assertEquals(298.15,
+        second.getThermalModel().getTemperature(CompressorThermalModel.AMBIENT, "K"), 1.0e-12);
+    assertThrows(IllegalArgumentException.class, () -> restored.apply("unknown", first));
+  }
+
+  @Test
+  void attachedModelAutoSolvesAndAppearsInEquipmentState() {
+    SystemSrkEos gas = new SystemSrkEos(298.15, 50.0);
+    gas.addComponent("methane", 0.90);
+    gas.addComponent("ethane", 0.10);
+    gas.setMixingRule("classic");
+    Stream inlet = new Stream("inlet", gas);
+    inlet.setFlowRate(10000.0, "kg/hr");
+    inlet.run();
+
+    Compressor compressor = new Compressor("thermal compressor", inlet);
+    compressor.setOutletPressure(100.0, "bara");
+    compressor.setIsentropicEfficiency(0.78);
+    compressor.initMechanicalLosses(120.0);
+    compressor.applyCatalogEntry(CompressorCatalog.createDefaultCatalog(),
+        "generic-centrifugal-single-stage");
+
+    compressor.run();
+
+    CompressorThermalModel model = compressor.getThermalModel();
+    assertEquals(inlet.getTemperature("K"),
+        model.getTemperature(CompressorThermalModel.SUCTION_GAS, "K"), 1.0e-10);
+    assertEquals(compressor.getOutletStream().getTemperature("K"),
+        model.getTemperature(CompressorThermalModel.DISCHARGE_GAS, "K"), 1.0e-10);
+    assertTrue(model.getTemperature(CompressorThermalModel.INLET_SHAFT, "K") > 250.0);
+
+    Map<String, Map<String, Object>> state = compressor.getEquipmentState("C", "bara", "kg/hr");
+    assertTrue(state.containsKey("thermal_inlet-shaft"));
+    assertTrue(state.containsKey("thermal_dry-gas-seal"));
+  }
+}

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorThermalModelTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorThermalModelTest.java
@@ -1,0 +1,70 @@
+package neqsim.process.equipment.compressor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import neqsim.process.equipment.compressor.CompressorThermalNode.NodeType;
+
+/** Tests for the compressor lumped thermal-network solver. */
+public class CompressorThermalModelTest {
+
+  @Test
+  void solvesAnalyticalThreeNodeSteadyState() {
+    CompressorThermalModel model = new CompressorThermalModel("analytical network");
+    model.addNode(new CompressorThermalNode("cold", NodeType.FLUID_BOUNDARY, 300.0, 0.0, true));
+    model.addNode(new CompressorThermalNode("hot", NodeType.FLUID_BOUNDARY, 400.0, 0.0, true));
+    CompressorThermalNode metal = new CompressorThermalNode("metal", NodeType.SHAFT, 320.0, 1000.0, false);
+    metal.setHeatGenerationW(100.0);
+    model.addNode(metal);
+    model.addLink(new CompressorThermalLink("cold", "metal", 10.0));
+    model.addLink(new CompressorThermalLink("hot", "metal", 10.0));
+
+    model.solveSteadyState();
+
+    assertEquals(355.0, model.getTemperature("metal", "K"), 1.0e-10);
+    assertEquals(81.85, model.getTemperature("metal", "C"), 1.0e-10);
+  }
+
+  @Test
+  void implicitTransientStepMatchesEnergyBalance() {
+    CompressorThermalModel model = new CompressorThermalModel("first order network");
+    model.addNode(new CompressorThermalNode("boundary", NodeType.FLUID_BOUNDARY, 400.0, 0.0, true));
+    model.addNode(new CompressorThermalNode("metal", NodeType.SHAFT, 300.0, 1000.0, false));
+    model.addLink(new CompressorThermalLink("boundary", "metal", 10.0));
+
+    model.solveTransient(100.0);
+
+    assertEquals(350.0, model.getTemperature("metal", "K"), 1.0e-10);
+    model.solveTransient(100.0);
+    assertEquals(375.0, model.getTemperature("metal", "K"), 1.0e-10);
+  }
+
+  @Test
+  void detectsInvalidAndSingularNetworks() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new CompressorThermalLink("a", "b", 0.0));
+
+    CompressorThermalModel noBoundary = new CompressorThermalModel();
+    noBoundary.addNode(new CompressorThermalNode("metal", NodeType.SHAFT, 300.0, 1000.0, false));
+    assertThrows(IllegalStateException.class, noBoundary::solveSteadyState);
+
+    CompressorThermalModel isolated = new CompressorThermalModel();
+    isolated.addNode(new CompressorThermalNode("boundary", NodeType.FLUID_BOUNDARY, 300.0, 0.0, true));
+    isolated.addNode(new CompressorThermalNode("metal", NodeType.SHAFT, 300.0, 1000.0, false));
+    assertThrows(IllegalStateException.class, isolated::solveSteadyState);
+  }
+
+  @Test
+  void jsonRoundTripCreatesIndependentNetwork() {
+    CompressorThermalModel original = CompressorCatalog.createDefaultCatalog()
+        .get("generic-centrifugal-single-stage").getThermalModel();
+    CompressorThermalModel restored = CompressorThermalModel.fromJson(original.toJson());
+
+    restored.getNode(CompressorThermalModel.AMBIENT).setTemperatureK(310.0);
+
+    assertEquals(298.15, original.getTemperature(CompressorThermalModel.AMBIENT, "K"), 1.0e-12);
+    assertEquals(310.0, restored.getTemperature(CompressorThermalModel.AMBIENT, "K"), 1.0e-12);
+    assertTrue(restored.getLinks().size() >= 10);
+  }
+}


### PR DESCRIPTION
## Summary

- add a steady-state and implicit-transient lumped thermal network for compressor shaft, impeller, casing, seal and bearing temperatures
- couple process-gas, seal-gas, lube-oil and mechanical-loss heat sources to the model
- add a JSON-backed compressor catalog with independent selectable templates and explicit calibration inputs
- expose thermal temperatures through `Compressor.getEquipmentState`
- add analytical solver, serialization, catalog and compressor-integration tests
- add literature-based documentation and an example notebook screening condensate evaporation at a warm inlet shaft

## Engineering scope

The generic conductances, heat capacities and rotor heat fraction are explicitly marked as screening assumptions. The documentation requires OEM data or fitted measurements for integrity decisions and explains that condensate evaporation is only one input to an elemental-sulfur deposition assessment.

## Validation

- Java sources parsed successfully with `java-parser`
- notebook JSON validated with `python3 -m json.tool`
- `git diff --check` clean
- full Maven build could not run in the local sandbox because Maven Central is unavailable; GitHub Actions is the authoritative compile/test/Spotless check for this draft

## References

Model rationale and links to API 617, API 692, experimental compressor heat-transfer, dry-gas-seal temperature, and calibrated lumped thermal-network literature are in `docs/compressor_thermal_model.md`.