### PR TITLE
Apply NeqSim formatter to compressor thermal model

### DIFF
--- a/src/main/java/neqsim/process/equipment/compressor/Compressor.java
+++ b/src/main/java/neqsim/process/equipment/compressor/Compressor.java
@@ -5116,7 +5116,7 @@ public class Compressor extends TwoPortEquipment
               // min
               // constraint
               .setMinValue(minSpeedLimit).setWarningThreshold(0.95) // Warning when within 5%
-                                                                    // of minimum
+              // of minimum
               .setValueSupplier(() -> this.speed).setEnabled(chartActive));
     }
 

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorCatalog.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorCatalog.java
@@ -18,8 +18,8 @@ import neqsim.process.equipment.compressor.CompressorThermalNode.NodeType;
  * JSON-backed catalog of selectable compressor definitions.
  *
  * <p>
- * Built-in entries are generic screening templates, not vendor performance guarantees. Users can
- * add private OEM definitions, serialize the catalog and select an entry by stable identifier.
+ * Built-in entries are generic screening templates, not vendor performance guarantees. Users can add private OEM
+ * definitions, serialize the catalog and select an entry by stable identifier.
  * </p>
  */
 public class CompressorCatalog implements Serializable {

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorCatalog.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorCatalog.java
@@ -26,11 +26,11 @@ public class CompressorCatalog implements Serializable {
   private static final long serialVersionUID = 1000L;
 
   private String name = "compressor catalog";
-  private final Map<String, CompressorCatalogEntry> entries =
-      new LinkedHashMap<String, CompressorCatalogEntry>();
+  private final Map<String, CompressorCatalogEntry> entries = new LinkedHashMap<String, CompressorCatalogEntry>();
 
   /** Create an empty catalog. */
-  public CompressorCatalog() {}
+  public CompressorCatalog() {
+  }
 
   /** @param name catalog name */
   public CompressorCatalog(String name) {
@@ -93,16 +93,14 @@ public class CompressorCatalog implements Serializable {
   public void apply(String id, Compressor compressor) {
     CompressorCatalogEntry entry = entries.get(id);
     if (entry == null) {
-      throw new IllegalArgumentException("no compressor catalog entry named '" + id
-          + "'; available: " + getIds());
+      throw new IllegalArgumentException("no compressor catalog entry named '" + id + "'; available: " + getIds());
     }
     entry.applyTo(compressor);
   }
 
   /** @return round-trippable pretty-printed JSON */
   public String toJson() {
-    return new GsonBuilder().serializeSpecialFloatingPointValues().setPrettyPrinting().create()
-        .toJson(this);
+    return new GsonBuilder().serializeSpecialFloatingPointValues().setPrettyPrinting().create().toJson(this);
   }
 
   /**
@@ -115,8 +113,7 @@ public class CompressorCatalog implements Serializable {
     if (json == null || json.trim().isEmpty()) {
       throw new IllegalArgumentException("compressor catalog JSON must not be empty");
     }
-    return new GsonBuilder().serializeSpecialFloatingPointValues().create().fromJson(json,
-        CompressorCatalog.class);
+    return new GsonBuilder().serializeSpecialFloatingPointValues().create().fromJson(json, CompressorCatalog.class);
   }
 
   /**
@@ -153,68 +150,51 @@ public class CompressorCatalog implements Serializable {
     return catalog;
   }
 
-  private static CompressorCatalogEntry createGenericEntry(String id, int stages,
-      double rotorHeatCapacity, double rotorGasConductance) {
+  private static CompressorCatalogEntry createGenericEntry(String id, int stages, double rotorHeatCapacity,
+      double rotorGasConductance) {
     CompressorThermalModel model = new CompressorThermalModel(id + " thermal network");
     model.addNode(boundary(CompressorThermalModel.SUCTION_GAS, 293.15));
     model.addNode(boundary(CompressorThermalModel.DISCHARGE_GAS, 373.15));
     model.addNode(boundary(CompressorThermalModel.SEAL_GAS, 313.15));
     model.addNode(boundary(CompressorThermalModel.LUBE_OIL, 320.65));
     model.addNode(boundary(CompressorThermalModel.AMBIENT, 298.15));
-    model.addNode(node(CompressorThermalModel.INLET_SHAFT, NodeType.SHAFT, 313.15,
-        0.35 * rotorHeatCapacity));
-    model.addNode(node(CompressorThermalModel.IMPELLER, NodeType.IMPELLER, 333.15,
-        0.65 * rotorHeatCapacity));
-    model.addNode(node(CompressorThermalModel.CASING, NodeType.CASING, 323.15,
-        1.2 * rotorHeatCapacity));
-    model.addNode(node(CompressorThermalModel.DRY_GAS_SEAL, NodeType.SEAL, 313.15,
-        5.0e4));
-    model.addNode(node(CompressorThermalModel.RADIAL_BEARING, NodeType.RADIAL_BEARING,
-        323.15, 8.0e4));
-    model.addNode(node(CompressorThermalModel.THRUST_BEARING, NodeType.THRUST_BEARING,
-        323.15, 8.0e4));
+    model.addNode(node(CompressorThermalModel.INLET_SHAFT, NodeType.SHAFT, 313.15, 0.35 * rotorHeatCapacity));
+    model.addNode(node(CompressorThermalModel.IMPELLER, NodeType.IMPELLER, 333.15, 0.65 * rotorHeatCapacity));
+    model.addNode(node(CompressorThermalModel.CASING, NodeType.CASING, 323.15, 1.2 * rotorHeatCapacity));
+    model.addNode(node(CompressorThermalModel.DRY_GAS_SEAL, NodeType.SEAL, 313.15, 5.0e4));
+    model.addNode(node(CompressorThermalModel.RADIAL_BEARING, NodeType.RADIAL_BEARING, 323.15, 8.0e4));
+    model.addNode(node(CompressorThermalModel.THRUST_BEARING, NodeType.THRUST_BEARING, 323.15, 8.0e4));
 
-    link(model, CompressorThermalModel.SUCTION_GAS, CompressorThermalModel.INLET_SHAFT,
-        80.0, Mechanism.CONVECTION);
-    link(model, CompressorThermalModel.DISCHARGE_GAS, CompressorThermalModel.IMPELLER,
-        rotorGasConductance, Mechanism.CONVECTION);
-    link(model, CompressorThermalModel.INLET_SHAFT, CompressorThermalModel.IMPELLER,
-        350.0, Mechanism.CONDUCTION);
-    link(model, CompressorThermalModel.IMPELLER, CompressorThermalModel.CASING, 90.0,
-        Mechanism.EFFECTIVE);
-    link(model, CompressorThermalModel.CASING, CompressorThermalModel.AMBIENT, 45.0,
+    link(model, CompressorThermalModel.SUCTION_GAS, CompressorThermalModel.INLET_SHAFT, 80.0, Mechanism.CONVECTION);
+    link(model, CompressorThermalModel.DISCHARGE_GAS, CompressorThermalModel.IMPELLER, rotorGasConductance,
         Mechanism.CONVECTION);
-    link(model, CompressorThermalModel.INLET_SHAFT, CompressorThermalModel.DRY_GAS_SEAL,
-        140.0, Mechanism.CONDUCTION);
-    link(model, CompressorThermalModel.DRY_GAS_SEAL, CompressorThermalModel.SEAL_GAS,
-        70.0, Mechanism.CONVECTION);
-    link(model, CompressorThermalModel.INLET_SHAFT, CompressorThermalModel.RADIAL_BEARING,
-        120.0, Mechanism.CONDUCTION);
-    link(model, CompressorThermalModel.INLET_SHAFT, CompressorThermalModel.THRUST_BEARING,
-        100.0, Mechanism.CONDUCTION);
-    link(model, CompressorThermalModel.RADIAL_BEARING, CompressorThermalModel.LUBE_OIL,
-        350.0, Mechanism.CONVECTION);
-    link(model, CompressorThermalModel.THRUST_BEARING, CompressorThermalModel.LUBE_OIL,
-        300.0, Mechanism.CONVECTION);
+    link(model, CompressorThermalModel.INLET_SHAFT, CompressorThermalModel.IMPELLER, 350.0, Mechanism.CONDUCTION);
+    link(model, CompressorThermalModel.IMPELLER, CompressorThermalModel.CASING, 90.0, Mechanism.EFFECTIVE);
+    link(model, CompressorThermalModel.CASING, CompressorThermalModel.AMBIENT, 45.0, Mechanism.CONVECTION);
+    link(model, CompressorThermalModel.INLET_SHAFT, CompressorThermalModel.DRY_GAS_SEAL, 140.0, Mechanism.CONDUCTION);
+    link(model, CompressorThermalModel.DRY_GAS_SEAL, CompressorThermalModel.SEAL_GAS, 70.0, Mechanism.CONVECTION);
+    link(model, CompressorThermalModel.INLET_SHAFT, CompressorThermalModel.RADIAL_BEARING, 120.0, Mechanism.CONDUCTION);
+    link(model, CompressorThermalModel.INLET_SHAFT, CompressorThermalModel.THRUST_BEARING, 100.0, Mechanism.CONDUCTION);
+    link(model, CompressorThermalModel.RADIAL_BEARING, CompressorThermalModel.LUBE_OIL, 350.0, Mechanism.CONVECTION);
+    link(model, CompressorThermalModel.THRUST_BEARING, CompressorThermalModel.LUBE_OIL, 300.0, Mechanism.CONVECTION);
     model.setCompressionHeatFractionToImpeller(0.002);
 
     CompressorCatalogEntry entry = new CompressorCatalogEntry(id, "NeqSim", "generic template");
     entry.setNumberOfStages(stages);
     entry.setThermalModel(model);
-    entry.requireParameter("thermal conductances W/K",
-        "Fit each link from OEM geometry, heat-transfer analysis or measured temperatures")
+    entry
+        .requireParameter("thermal conductances W/K",
+            "Fit each link from OEM geometry, heat-transfer analysis or measured temperatures")
         .requireParameter("node heat capacities J/K",
             "Calculate from participating metal mass and temperature-dependent heat capacity")
-        .requireParameter("bearing losses kW",
-            "Use vendor loss curves, oil heat balance or a validated bearing model")
+        .requireParameter("bearing losses kW", "Use vendor loss curves, oil heat balance or a validated bearing model")
         .requireParameter("seal and lube-oil temperatures C",
             "Use measured supply and return temperatures at the operating condition")
         .requireParameter("compression heat fraction",
             "Fit the rotor heat pickup; the generic value is only a screening assumption")
         .addReference("API 617", "Axial and Centrifugal Compressors and Expander-compressors")
         .addReference("API 692", "Dry Gas Sealing Systems for Compressors and Expanders")
-        .addReference("model equation",
-            "Lumped thermal capacitance energy balance solved as a resistance network");
+        .addReference("model equation", "Lumped thermal capacitance energy balance solved as a resistance network");
     return entry;
   }
 
@@ -222,13 +202,12 @@ public class CompressorCatalog implements Serializable {
     return new CompressorThermalNode(id, NodeType.FLUID_BOUNDARY, temperatureK, 0.0, true);
   }
 
-  private static CompressorThermalNode node(String id, NodeType type, double temperatureK,
-      double heatCapacityJPerK) {
+  private static CompressorThermalNode node(String id, NodeType type, double temperatureK, double heatCapacityJPerK) {
     return new CompressorThermalNode(id, type, temperatureK, heatCapacityJPerK, false);
   }
 
-  private static void link(CompressorThermalModel model, String from, String to,
-      double conductance, Mechanism mechanism) {
+  private static void link(CompressorThermalModel model, String from, String to, double conductance,
+      Mechanism mechanism) {
     model.addLink(new CompressorThermalLink(from, to, conductance, mechanism));
   }
 }

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorCatalogEntry.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorCatalogEntry.java
@@ -19,7 +19,8 @@ public class CompressorCatalogEntry implements Serializable {
   private final Map<String, String> references = new LinkedHashMap<String, String>();
 
   /** No-argument constructor for JSON deserialization. */
-  public CompressorCatalogEntry() {}
+  public CompressorCatalogEntry() {
+  }
 
   /**
    * Create a catalog entry.

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorThermalLink.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorThermalLink.java
@@ -22,7 +22,8 @@ public class CompressorThermalLink implements Serializable {
   private Mechanism mechanism = Mechanism.EFFECTIVE;
 
   /** No-argument constructor for JSON deserialization. */
-  public CompressorThermalLink() {}
+  public CompressorThermalLink() {
+  }
 
   /**
    * Create a thermal link.
@@ -43,8 +44,7 @@ public class CompressorThermalLink implements Serializable {
    * @param conductanceWPerK effective conductance in W/K
    * @param mechanism heat-transfer mechanism
    */
-  public CompressorThermalLink(String fromNodeId, String toNodeId, double conductanceWPerK,
-      Mechanism mechanism) {
+  public CompressorThermalLink(String fromNodeId, String toNodeId, double conductanceWPerK, Mechanism mechanism) {
     setFromNodeId(fromNodeId);
     setToNodeId(toNodeId);
     setConductanceWPerK(conductanceWPerK);

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorThermalModel.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorThermalModel.java
@@ -53,15 +53,15 @@ public class CompressorThermalModel implements Serializable {
   public static final String AMBIENT = "ambient";
 
   private String name = "compressor thermal model";
-  private final Map<String, CompressorThermalNode> nodes =
-      new LinkedHashMap<String, CompressorThermalNode>();
+  private final Map<String, CompressorThermalNode> nodes = new LinkedHashMap<String, CompressorThermalNode>();
   private final List<CompressorThermalLink> links = new ArrayList<CompressorThermalLink>();
   private boolean autoSolve = true;
   private boolean useMechanicalLossHeatSources = true;
   private double compressionHeatFractionToImpeller = 0.0;
 
   /** Create an empty thermal network. */
-  public CompressorThermalModel() {}
+  public CompressorThermalModel() {
+  }
 
   /** @param name descriptive model name */
   public CompressorThermalModel(String name) {
@@ -184,15 +184,13 @@ public class CompressorThermalModel implements Serializable {
     if (compressor.getInletStream() != null) {
       setBoundaryIfPresent(SUCTION_GAS, compressor.getInletStream().getTemperature("K"));
     }
-    if (compressor.getOutletStream() != null
-        && compressor.getOutletStream().getThermoSystem() != null) {
+    if (compressor.getOutletStream() != null && compressor.getOutletStream().getThermoSystem() != null) {
       setBoundaryIfPresent(DISCHARGE_GAS, compressor.getOutletStream().getTemperature("K"));
     }
     CompressorMechanicalLosses losses = compressor.getMechanicalLosses();
     if (losses != null) {
       setBoundaryIfPresent(SEAL_GAS, losses.getSealGasSupplyTemperature() + 273.15);
-      double oilTemperatureK =
-          0.5 * (losses.getLubeOilInletTemp() + losses.getLubeOilOutletTemp()) + 273.15;
+      double oilTemperatureK = 0.5 * (losses.getLubeOilInletTemp() + losses.getLubeOilOutletTemp()) + 273.15;
       setBoundaryIfPresent(LUBE_OIL, oilTemperatureK);
     }
   }
@@ -251,8 +249,7 @@ public class CompressorThermalModel implements Serializable {
         hasBoundary = true;
       } else {
         if (transientStep && node.getHeatCapacityJPerK() <= 0.0) {
-          throw new IllegalStateException("transient node '" + node.getId()
-              + "' must have positive heat capacity");
+          throw new IllegalStateException("transient node '" + node.getId() + "' must have positive heat capacity");
         }
         unknownIndex.put(node.getId(), unknowns.size());
         unknowns.add(node);
@@ -278,10 +275,10 @@ public class CompressorThermalModel implements Serializable {
     }
 
     for (CompressorThermalLink link : links) {
-      addLinkToEquations(link.getFromNodeId(), link.getToNodeId(), link.getConductanceWPerK(),
-          unknownIndex, coefficients, rightHandSide);
-      addLinkToEquations(link.getToNodeId(), link.getFromNodeId(), link.getConductanceWPerK(),
-          unknownIndex, coefficients, rightHandSide);
+      addLinkToEquations(link.getFromNodeId(), link.getToNodeId(), link.getConductanceWPerK(), unknownIndex,
+          coefficients, rightHandSide);
+      addLinkToEquations(link.getToNodeId(), link.getFromNodeId(), link.getConductanceWPerK(), unknownIndex,
+          coefficients, rightHandSide);
     }
     double[] solution = solveLinearSystem(coefficients, rightHandSide);
     for (int i = 0; i < unknowns.size(); i++) {
@@ -410,8 +407,7 @@ public class CompressorThermalModel implements Serializable {
 
   /** @return pretty-printed, round-trippable JSON */
   public String toJson() {
-    return new GsonBuilder().serializeSpecialFloatingPointValues().setPrettyPrinting().create()
-        .toJson(this);
+    return new GsonBuilder().serializeSpecialFloatingPointValues().setPrettyPrinting().create().toJson(this);
   }
 
   /**

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorThermalModel.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorThermalModel.java
@@ -12,18 +12,16 @@ import com.google.gson.GsonBuilder;
  * Lumped-parameter thermal network for a compressor.
  *
  * <p>
- * Each non-boundary node obeys {@code C dT/dt = Q + sum(G * (Tneighbour - T))}. The
- * steady-state and implicit-Euler transient solvers use the same network. Conductances and heat
- * capacities are deliberately explicit calibration parameters: local metal temperatures depend on
- * machine geometry, material, oil flow, seal flow and operating history and cannot be inferred from
- * the process-gas outlet temperature alone.
+ * Each non-boundary node obeys {@code C dT/dt = Q + sum(G * (Tneighbour - T))}. The steady-state and implicit-Euler
+ * transient solvers use the same network. Conductances and heat capacities are deliberately explicit calibration
+ * parameters: local metal temperatures depend on machine geometry, material, oil flow, seal flow and operating history
+ * and cannot be inferred from the process-gas outlet temperature alone.
  * </p>
  *
  * <p>
- * API 617 and API 692 define the relevant compressor, bearing and dry-gas-seal system scope. They
- * do not provide a universal rotor thermal network. Template values supplied by
- * {@link CompressorCatalog} are therefore screening values and should be replaced with OEM data or
- * fitted plant measurements before integrity decisions are made.
+ * API 617 and API 692 define the relevant compressor, bearing and dry-gas-seal system scope. They do not provide a
+ * universal rotor thermal network. Template values supplied by {@link CompressorCatalog} are therefore screening values
+ * and should be replaced with OEM data or fitted plant measurements before integrity decisions are made.
  * </p>
  */
 public class CompressorThermalModel implements Serializable {

--- a/src/main/java/neqsim/process/equipment/compressor/CompressorThermalNode.java
+++ b/src/main/java/neqsim/process/equipment/compressor/CompressorThermalNode.java
@@ -35,7 +35,8 @@ public class CompressorThermalNode implements Serializable {
   private boolean fixedTemperature;
 
   /** No-argument constructor for JSON deserialization. */
-  public CompressorThermalNode() {}
+  public CompressorThermalNode() {
+  }
 
   /**
    * Create a thermal node.
@@ -46,8 +47,8 @@ public class CompressorThermalNode implements Serializable {
    * @param heatCapacityJPerK lumped heat capacity in J/K
    * @param fixedTemperature whether the node is an imposed boundary temperature
    */
-  public CompressorThermalNode(String id, NodeType type, double temperatureK,
-      double heatCapacityJPerK, boolean fixedTemperature) {
+  public CompressorThermalNode(String id, NodeType type, double temperatureK, double heatCapacityJPerK,
+      boolean fixedTemperature) {
     setId(id);
     setType(type);
     setTemperatureK(temperatureK);

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorCatalogTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorCatalogTest.java
@@ -37,8 +37,7 @@ public class CompressorCatalogTest {
 
     assertNotSame(first.getThermalModel(), second.getThermalModel());
     first.getThermalModel().getNode(CompressorThermalModel.AMBIENT).setTemperatureK(315.0);
-    assertEquals(298.15,
-        second.getThermalModel().getTemperature(CompressorThermalModel.AMBIENT, "K"), 1.0e-12);
+    assertEquals(298.15, second.getThermalModel().getTemperature(CompressorThermalModel.AMBIENT, "K"), 1.0e-12);
     assertThrows(IllegalArgumentException.class, () -> restored.apply("unknown", first));
   }
 
@@ -56,14 +55,12 @@ public class CompressorCatalogTest {
     compressor.setOutletPressure(100.0, "bara");
     compressor.setIsentropicEfficiency(0.78);
     compressor.initMechanicalLosses(120.0);
-    compressor.applyCatalogEntry(CompressorCatalog.createDefaultCatalog(),
-        "generic-centrifugal-single-stage");
+    compressor.applyCatalogEntry(CompressorCatalog.createDefaultCatalog(), "generic-centrifugal-single-stage");
 
     compressor.run();
 
     CompressorThermalModel model = compressor.getThermalModel();
-    assertEquals(inlet.getTemperature("K"),
-        model.getTemperature(CompressorThermalModel.SUCTION_GAS, "K"), 1.0e-10);
+    assertEquals(inlet.getTemperature("K"), model.getTemperature(CompressorThermalModel.SUCTION_GAS, "K"), 1.0e-10);
     assertEquals(compressor.getOutletStream().getTemperature("K"),
         model.getTemperature(CompressorThermalModel.DISCHARGE_GAS, "K"), 1.0e-10);
     assertTrue(model.getTemperature(CompressorThermalModel.INLET_SHAFT, "K") > 250.0);

--- a/src/test/java/neqsim/process/equipment/compressor/CompressorThermalModelTest.java
+++ b/src/test/java/neqsim/process/equipment/compressor/CompressorThermalModelTest.java
@@ -42,8 +42,7 @@ public class CompressorThermalModelTest {
 
   @Test
   void detectsInvalidAndSingularNetworks() {
-    assertThrows(IllegalArgumentException.class,
-        () -> new CompressorThermalLink("a", "b", 0.0));
+    assertThrows(IllegalArgumentException.class, () -> new CompressorThermalLink("a", "b", 0.0));
 
     CompressorThermalModel noBoundary = new CompressorThermalModel();
     noBoundary.addNode(new CompressorThermalNode("metal", NodeType.SHAFT, 300.0, 1000.0, false));
@@ -57,8 +56,8 @@ public class CompressorThermalModelTest {
 
   @Test
   void jsonRoundTripCreatesIndependentNetwork() {
-    CompressorThermalModel original = CompressorCatalog.createDefaultCatalog()
-        .get("generic-centrifugal-single-stage").getThermalModel();
+    CompressorThermalModel original = CompressorCatalog.createDefaultCatalog().get("generic-centrifugal-single-stage")
+        .getThermalModel();
     CompressorThermalModel restored = CompressorThermalModel.fromJson(original.toJson());
 
     restored.getNode(CompressorThermalModel.AMBIENT).setTemperatureK(310.0);


### PR DESCRIPTION
Follow-up to #77, which was merged while its CI run was still active.

This PR contains only the Eclipse/Spotless formatting changes reported by the `Pre-commit checks` job. It uses `.config/neqsim_formatter.xml` and does not change thermal-model behavior.

Validation before push:
- all eight changed Java files parsed successfully
- `git diff --check` clean
- the #77 run had already passed Javadoc/compilation and CodeQL before this formatting-only correction